### PR TITLE
Changes for #394 & #397

### DIFF
--- a/Functions/Other/fn_handleWaitingForReviveEvent.sqf
+++ b/Functions/Other/fn_handleWaitingForReviveEvent.sqf
@@ -63,7 +63,7 @@ private _fn_addReviveAction = {
 		{},
 		[],
 		1,
-		100,
+		10000,
 		false,
 		true
 	] call BIS_fnc_holdActionAdd;

--- a/Functions/Waves/fn_decideWaveType.sqf
+++ b/Functions/Waves/fn_decideWaveType.sqf
@@ -24,7 +24,7 @@ Author(s):
 	Hilltop(Willtop) & omNomios,
 	Modified by: Ansible2 // Cipher
 ---------------------------------------------------------------------------- */
-#define SPECIAL_WAVE_LIKELIHOOD 0.4
+#define SPECIAL_WAVE_LIKELIHOOD 0.3
 #define STANDARD_WAVE_LIKELIHOOD 1.25
 #define SPECIAL_WAVES \
 [ \


### PR DESCRIPTION
- Medkit revive action not showing when downed
- Special waves happen too often relative to vehicle waves

Changes:
- Upped priority of revive action
- Lowered special wave likelihood to 0.3 from 0.4