### PR TITLE
Added mission parameter to select how enemy units are spawned around the map

### DIFF
--- a/Functions/Init Functions/fn_prepareGlobals.sqf
+++ b/Functions/Init Functions/fn_prepareGlobals.sqf
@@ -146,7 +146,8 @@ if (isServer OR {!hasInterface}) then {
     // What wave enemies stop only using pistols  
     BLWK_maxPistolOnlyWaves = ("BLWK_maxPistolOnlyWaves" call BIS_fnc_getParamValue);  
     BLWK_randomizeEnemyWeapons = [false,true] select ("BLWK_randomizeEnemyWeapons" call BIS_fnc_getParamValue);
-
+	BLWK_randomizeEnemyDirection = [false,true] select ("BLWK_randomizeEnemyDirection" call BIS_fnc_getParamValue);
+	
     BLWK_vehicleStartWave = ("BLWK_vehicleStartWave" call BIS_fnc_getParamValue);
     BLWK_specialWavesStartAt = ("BLWK_specialWavesStartAt" call BIS_fnc_getParamValue);
 

--- a/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
+++ b/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
@@ -81,8 +81,13 @@ private _fn_selectEnemyType = {
 
 // cache AI spawn info for queue
 private ["_spawnPositionTemp","_typeTemp"];
+if(!BLWK_randomizeEnemyDirection) then {
+_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
+};
 for "_i" from 1 to _totalNumEnemiesToSpawnDuringWave do {
+	if(BLWK_randomizeEnemyDirection) then{
 	_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
+	};
 	_typeTemp = call _fn_selectEnemyType;
 
 	[STANDARD_ENEMY_INFANTRY_QUEUE,_typeTemp,_spawnPositionTemp] call BLWK_fnc_addToQueue;

--- a/Headers/descriptionEXT/missionParams.hpp
+++ b/Headers/descriptionEXT/missionParams.hpp
@@ -94,6 +94,13 @@ class BLWK_randomizeEnemyWeapons
 	texts[] = NO_OR_YES;
 	GET_DEFAULT_PARAM(BLWK_randomizeEnemyWeapons,0)
 };
+class BLWK_randomizeEnemyDirection
+{
+	title = "Enemy Spawn Direction";
+	values[] = ZERO_OR_ONE;
+	texts[] = {"Single Random Location Each Round","Many Random Locations Each Round"};
+	GET_DEFAULT_PARAM(BLWK_randomizeEnemyDirection,1)
+};
 class BLWK_maxPistolOnlyWaves
 {
 	title = "Hostiles only use pistols until wave";


### PR DESCRIPTION
Hello Ansible2,

I had a interesting idea about how units are spawned in this game mode. I thought it could be a fun parameter to change the spawning location to be a single random point where all enemies of the wave are spawned. What is neat about this is all the enemies of the wave come from the same direction, and it feels like a coordinated attack wave is coming in. It allows players to coordinate a defense towards a direction, and surprises when the enemy starts to flank the players.

I have play tested it and it is alot of fun. It feels a little more cinematic with the enemies moving in what looks like a large squad upon first contact. Its also a nice change of pace when the direction changes every wave and the enemies probes your defenses from a new direction.

The setting is a boolean, where the default is the spawn enemies in all directions, or the new option to spawn enemies from a single direction each round. I placed the setting with the other wave settings.

* Added mission parameter to select how enemy units are spawned around the map
* can select between (all enemies spawned at a single random location each round) or original default (all enemies spawned at many random locations in all directions each round)