### PR TITLE
Add loot limit and removed deletion of loot holders every wave

### DIFF
--- a/Functions/Init Functions/fn_prepareGlobals.sqf
+++ b/Functions/Init Functions/fn_prepareGlobals.sqf
@@ -77,7 +77,7 @@ if (isServer) then {
 
     // for revealing loot and deleteing it at the end of the round
     BLWK_lootMarkers = [];
-    BLWK_spawnedLoot = [];
+    BLWK_lootHolders = [];
 
     // the marker that denotes the play area on the map
     BLWK_playAreaMarker = "";

--- a/Functions/Init Functions/fn_prepareGlobals.sqf
+++ b/Functions/Init Functions/fn_prepareGlobals.sqf
@@ -62,6 +62,7 @@ if (isServer) then {
     /* Random Loot */
     BLWK_loot_cityDistribution = ("BLWK_loot_cityDistribution" call BIS_fnc_getParamValue);  // decides how many buildings will be marked as having loot in a city
     BLWK_loot_roomDistribution = ("BLWK_loot_roomDistribution" call BIS_fnc_getParamValue);  // decides how much loot will be in a building if it has any at all
+    BLWK_maxLootSpawns = "BLWK_maxLootSpawns" call BIS_fnc_getParamValue;
 
     /* Time of Day*/
     BLWK_timeOfDay = ("BLWK_timeOfDay" call BIS_fnc_getParamValue);

--- a/Functions/Supports/fn_createLootMarkers.sqf
+++ b/Functions/Supports/fn_createLootMarkers.sqf
@@ -184,7 +184,7 @@ private "_isUniqueItem_temp";
 		_lootIndex_temp = _forEachIndex;
 		call _fn_createMarker;
 	};
-} forEach BLWK_spawnedLoot;
+} forEach BLWK_lootHolders;
 
 
 nil
@@ -277,6 +277,6 @@ private _fn_setUpMarker = {
 	private _marker = [_x,_forEachIndex] call _fn_setUpMarker;
 
 	BLWK_lootMarkers pushBack _marker;
-} forEach BLWK_spawnedLoot;
+} forEach BLWK_lootHolders;
 
 */

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -23,10 +23,9 @@ Author(s):
 ---------------------------------------------------------------------------- */
 if (!isServer) exitWith {false};
 
+
 /* ----------------------------------------------------------------------------
-
 	Delete Previous Loot
-
 ---------------------------------------------------------------------------- */
 if !((missionNamespace getVariable ["BLWK_lootMarkers",[]]) isEqualTo []) then {
 	BLWK_lootMarkers apply {
@@ -35,31 +34,33 @@ if !((missionNamespace getVariable ["BLWK_lootMarkers",[]]) isEqualTo []) then {
 };
 private _randomWeaponBoxFound = missionNamespace getVariable ["BLWK_randomWeaponBoxFound",false];
 // check if there is any loot to delete
-if !((missionNamespace getVariable ["BLWK_spawnedLoot",[]]) isEqualTo []) then {
+if ((missionNamespace getVariable ["BLWK_lootHolders",[]]) isNotEqualTo []) then {
+
 	if (_randomWeaponBoxFound) then {
-		if (BLWK_randomWeaponBox in BLWK_spawnedLoot) then {
-			BLWK_spawnedLoot deleteAt (BLWK_spawnedLoot findIf {_x isEqualTo BLWK_randomWeaponBox});
+		if (BLWK_randomWeaponBox in BLWK_lootHolders) then {
+			BLWK_lootHolders deleteAt (BLWK_lootHolders findIf {_x isEqualTo BLWK_randomWeaponBox});
 		};
 	};
-	BLWK_spawnedLoot apply {
+
+	BLWK_lootHolders apply {
 		_x setVariable ["BLWK_primaryLootClass",nil];
 		deleteVehicle _x;
 	};
+
 };
 
+
 /* ----------------------------------------------------------------------------
-
 	Prepare Spawn Positions
-
 ---------------------------------------------------------------------------- */
 // get ALL buildings in area
 private _buildingsInPlayArea = nearestTerrainObjects [BLWK_playAreaCenter,["House"], BLWK_playAreaRadius, false, true];
 
+// make sure the building has configed positions to spawn stuff at
 BLWK_playAreaBuildings = _buildingsInPlayArea select {
-	!((_x buildingPos -1) isEqualTo [])
+	((_x buildingPos -1) isNotEqualTo [])
 };
 
-private _buildings = BLWK_playAreaBuildings;
 // sort through all available buildings and positions
 private _sortedPositions = [];
 {
@@ -75,7 +76,7 @@ private _sortedPositions = [];
 			};
 		} forEach _buildingsPositions;
 	};
-} forEach _buildings;
+} forEach BLWK_playAreaBuildings;
 
 
 private _fn_getASpawnPosition = {
@@ -104,7 +105,7 @@ _addToZeusArray pushBack BLWK_lootRevealerBox;
 
 [BLWK_lootRevealerBox] remoteExec ["BLWK_fnc_addRevealLootAction",BLWK_allClientsTargetID,BLWK_lootRevealerBox];
 // add to list to for cleanup
-BLWK_spawnedLoot pushBack BLWK_lootRevealerBox;
+BLWK_lootHolders pushBack BLWK_lootRevealerBox;
 
 
 // SUPPORT UNLOCK DISH
@@ -115,7 +116,7 @@ if (!BLWK_supportDishFound) then {
 	_addToZeusArray pushBack BLWK_supportDish;
 
 	[BLWK_supportDish] remoteExecCall ["BLWK_fnc_addUnlockSupportAction",BLWK_allClientsTargetID,BLWK_supportDish];
-	BLWK_spawnedLoot pushBack BLWK_supportDish;
+	BLWK_lootHolders pushBack BLWK_supportDish;
 };
 
 // RANDOM WEAPON BOX
@@ -127,7 +128,7 @@ if (!_randomWeaponBoxFound) then {
 
 	[BLWK_randomWeaponBox] remoteExecCall ["BLWK_fnc_addBuildableObjectActions",BLWK_allClientsTargetID,true];
 	[BLWK_randomWeaponBox] remoteExecCall ["BLWK_fnc_addWeaponBoxSpinAction",BLWK_allClientsTargetID,true];
-	BLWK_spawnedLoot pushBack BLWK_randomWeaponBox;
+	BLWK_lootHolders pushBack BLWK_randomWeaponBox;
 };
 
 // MONEY PILE
@@ -137,7 +138,7 @@ BLWK_moneyPile allowDamage false;
 _addToZeusArray pushBack BLWK_moneyPile;
 
 [BLWK_moneyPile] remoteExecCall ["BLWK_fnc_addMoneyPileAction",BLWK_allClientsTargetID,BLWK_moneyPile];
-BLWK_spawnedLoot pushBack BLWK_moneyPile;
+BLWK_lootHolders pushBack BLWK_moneyPile;
 
 // CIPHER COMMENT:
 // items should probably never repeat themselves in a round
@@ -254,7 +255,7 @@ _sortedPositions apply {
 	_holder setVariable ["BLWK_primaryLootClass",_primaryLootClass];
 
 	_addToZeusArray pushBack _holder;
-	BLWK_spawnedLoot pushBack _holder;
+	BLWK_lootHolders pushBack _holder;
 };
 
 [BLWK_zeus, [_addToZeusArray,true]] remoteExecCall ["addCuratorEditableObjects",2];

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -67,7 +67,7 @@ if (isNil "BLWK_playAreaBuildings" /*OR {playAreaSizeWasChanged}*/) then {
 	//playAreaSizeWasChanged = false;
 } else {
 	// randomize buildings because the forEach loop below will be the same every time then
-	[BLWK_playAreaBuildings] call CBAP_fnc_shuffle;
+	BLWK_playAreaBuildings = [BLWK_playAreaBuildings,true] call CBAP_fnc_shuffle;
 };
 
 // sort through all available buildings and positions

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -25,7 +25,7 @@ Author(s):
 #define SUPPORT_SATT_CLASS "Land_SatelliteAntenna_01_F"
 #define MONEY_PILE_CLASS "Land_Money_F"
 #define LOOT_REVEAL_BOX_CLASS "Box_C_UAV_06_Swifd_F"
-#define LOOT_HOLDER_CLASS "WeaponHolderSimulated";
+#define LOOT_HOLDER_CLASS "WeaponHolderSimulated"
 
 if (!isServer) exitWith {false};
 
@@ -42,10 +42,8 @@ private _randomWeaponBoxFound = missionNamespace getVariable ["BLWK_randomWeapon
 // check if there is any loot to delete
 if ((missionNamespace getVariable ["BLWK_lootHolders",[]]) isNotEqualTo []) then {
 
-	if (_randomWeaponBoxFound) then {
-		if (BLWK_randomWeaponBox in BLWK_lootHolders) then {
-			BLWK_lootHolders deleteAt (BLWK_lootHolders findIf {_x isEqualTo BLWK_randomWeaponBox});
-		};
+	if (_randomWeaponBoxFound AND {BLWK_randomWeaponBox in BLWK_lootHolders}) then {
+		BLWK_lootHolders deleteAt (BLWK_lootHolders findIf {_x isEqualTo BLWK_randomWeaponBox});
 	};
 
 	BLWK_lootHolders apply {

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -123,7 +123,7 @@ _addToZeusArray pushBack BLWK_lootRevealerBox;
 
 [BLWK_lootRevealerBox] remoteExec ["BLWK_fnc_addRevealLootAction",BLWK_allClientsTargetID,BLWK_lootRevealerBox];
 // add to list to for cleanup
-BLWK_lootHolders pushBack BLWK_lootRevealerBox;
+//BLWK_lootHolders pushBack BLWK_lootRevealerBox;
 
 
 // SUPPORT UNLOCK DISH
@@ -134,7 +134,7 @@ if (!BLWK_supportDishFound) then {
 	_addToZeusArray pushBack BLWK_supportDish;
 
 	[BLWK_supportDish] remoteExecCall ["BLWK_fnc_addUnlockSupportAction",BLWK_allClientsTargetID,BLWK_supportDish];
-	BLWK_lootHolders pushBack BLWK_supportDish;
+	//BLWK_lootHolders pushBack BLWK_supportDish;
 };
 
 // RANDOM WEAPON BOX
@@ -156,7 +156,7 @@ BLWK_moneyPile allowDamage false;
 _addToZeusArray pushBack BLWK_moneyPile;
 
 [BLWK_moneyPile] remoteExecCall ["BLWK_fnc_addMoneyPileAction",BLWK_allClientsTargetID,BLWK_moneyPile];
-BLWK_lootHolders pushBack BLWK_moneyPile;
+//BLWK_lootHolders pushBack BLWK_moneyPile;
 
 // CIPHER COMMENT:
 // items should probably never repeat themselves in a round

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -62,6 +62,8 @@ if (isNil "BLWK_playAreaBuildings" /*OR {playAreaSizeWasChanged}*/) then {
 	BLWK_playAreaBuildings = _buildingsInPlayArea select {
 		((_x buildingPos -1) isNotEqualTo [])
 	};
+
+	BLWK_playAreaBuildings = [BLWK_playAreaBuildings,true] call CBAP_fnc_shuffle;
 	//playAreaSizeWasChanged = false;
 } else {
 	// randomize buildings because the forEach loop below will be the same every time then
@@ -70,7 +72,10 @@ if (isNil "BLWK_playAreaBuildings" /*OR {playAreaSizeWasChanged}*/) then {
 
 // sort through all available buildings and positions
 private _sortedPositions = [];
+private _exit = false;
 {
+	if (_exit) then {break};
+
 	private _currentBuilding = _x;
 	private _buildingIndex = _forEachIndex;
 	// to distribute to every building, every other building, every 3rd, etc.
@@ -78,6 +83,8 @@ private _sortedPositions = [];
 		private _buildingsPositions = _currentBuilding buildingPos -1;
 
 		{
+			if (count _sortedPositions >= BLWK_maxLootSpawns) then {_exit = true; break};
+
 			if (_forEachIndex isEqualTo 0 OR {(_forEachIndex mod BLWK_loot_roomDistribution) isEqualTo 0}) then {
 				_sortedPositions pushBack _x
 			};

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -21,6 +21,12 @@ Author(s):
 	Hilltop(Willtop) & omNomios,
 	Modified by: Ansible2 // Cipher
 ---------------------------------------------------------------------------- */
+#define RANDOM_WEAPON_BOX_CLASS "Land_WoodenBox_F"
+#define SUPPORT_SATT_CLASS "Land_SatelliteAntenna_01_F"
+#define MONEY_PILE_CLASS "Land_Money_F"
+#define LOOT_REVEAL_BOX_CLASS "Box_C_UAV_06_Swifd_F"
+#define LOOT_HOLDER_CLASS "WeaponHolderSimulated";
+
 if (!isServer) exitWith {false};
 
 
@@ -113,7 +119,7 @@ private _addToZeusArray = [];
 
 // LOOT REVEAL BOX
 // these are global for future endeavors
-BLWK_lootRevealerBox = createVehicle ["Box_C_UAV_06_Swifd_F", (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
+BLWK_lootRevealerBox = createVehicle [LOOT_REVEAL_BOX_CLASS, (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
 publicVariable "BLWK_lootRevealerBox";
 _addToZeusArray pushBack BLWK_lootRevealerBox;
 
@@ -124,7 +130,7 @@ BLWK_lootHolders pushBack BLWK_lootRevealerBox;
 
 // SUPPORT UNLOCK DISH
 if (!BLWK_supportDishFound) then {
-	BLWK_supportDish = createVehicle ["Land_SatelliteAntenna_01_F", (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
+	BLWK_supportDish = createVehicle [SUPPORT_SATT_CLASS, (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
 	publicVariable "BLWK_supportDish";
 	BLWK_supportDish allowDamage false;
 	_addToZeusArray pushBack BLWK_supportDish;
@@ -135,7 +141,7 @@ if (!BLWK_supportDishFound) then {
 
 // RANDOM WEAPON BOX
 if (!_randomWeaponBoxFound) then {
-	BLWK_randomWeaponBox = createVehicle ["Land_WoodenBox_F", (call _fn_getASpawnPosition), [], 4];
+	BLWK_randomWeaponBox = createVehicle [RANDOM_WEAPON_BOX_CLASS, (call _fn_getASpawnPosition), [], 4];
 	publicVariable "BLWK_randomWeaponBox";
 	BLWK_randomWeaponBox allowDamage false;
 	_addToZeusArray pushBack BLWK_randomWeaponBox;
@@ -146,7 +152,7 @@ if (!_randomWeaponBoxFound) then {
 };
 
 // MONEY PILE
-BLWK_moneyPile = createVehicle ["Land_Money_F", (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
+BLWK_moneyPile = createVehicle [MONEY_PILE_CLASS, (call _fn_getASpawnPosition), [], 0, "CAN_COLLIDE"];
 publicVariable "BLWK_moneyPile";
 BLWK_moneyPile allowDamage false;
 _addToZeusArray pushBack BLWK_moneyPile;
@@ -263,7 +269,7 @@ private _fn_addLoot = {
 _sortedPositions apply {
 	// in order to spawn stuff like weapons on the ground, we create holders
 
-	private _holder = createVehicle ["WeaponHolderSimulated", _x, [], 0, "CAN_COLLIDE"];
+	private _holder = createVehicle [LOOT_HOLDER_CLASS, _x, [], 0, "CAN_COLLIDE"];
 	private _primaryLootClass = [_holder] call _fn_addLoot;
 	// used for displaying loot markers in BLWK_fnc_createLootMarkers
 	_holder setVariable ["BLWK_primaryLootClass",_primaryLootClass];
@@ -272,7 +278,7 @@ _sortedPositions apply {
 	BLWK_lootHolders pushBack _holder;
 };
 
-[BLWK_zeus, [_addToZeusArray,true]] remoteExecCall ["addCuratorEditableObjects",2];
+BLWK_zeus addCuratorEditableObjects [_addToZeusArray,true];
 
 
 true

--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -53,12 +53,19 @@ if ((missionNamespace getVariable ["BLWK_lootHolders",[]]) isNotEqualTo []) then
 /* ----------------------------------------------------------------------------
 	Prepare Spawn Positions
 ---------------------------------------------------------------------------- */
-// get ALL buildings in area
-private _buildingsInPlayArea = nearestTerrainObjects [BLWK_playAreaCenter,["House"], BLWK_playAreaRadius, false, true];
+// Add a bool variable to this in the future to check if the play area size changed
+if (isNil "BLWK_playAreaBuildings" /*OR {playAreaSizeWasChanged}*/) then {
+	// get ALL buildings in area
+	private _buildingsInPlayArea = nearestTerrainObjects [BLWK_playAreaCenter,["House"], BLWK_playAreaRadius, false, true];
 
-// make sure the building has configed positions to spawn stuff at
-BLWK_playAreaBuildings = _buildingsInPlayArea select {
-	((_x buildingPos -1) isNotEqualTo [])
+	// make sure the building has configed positions to spawn stuff at
+	BLWK_playAreaBuildings = _buildingsInPlayArea select {
+		((_x buildingPos -1) isNotEqualTo [])
+	};
+	//playAreaSizeWasChanged = false;
+} else {
+	// randomize buildings because the forEach loop below will be the same every time then
+	[BLWK_playAreaBuildings] call CBAP_fnc_shuffle;
 };
 
 // sort through all available buildings and positions

--- a/Functions/Waves/fn_startWave.sqf
+++ b/Functions/Waves/fn_startWave.sqf
@@ -35,7 +35,7 @@ params [
 
 // wait for array to be cleared
 /*
-	it's rare, but if enemies die too quickly, 
+	it's rare, but if enemies die too quickly,
 	this can cause overlap in the next wave of enemies.
 	These are people that were just being added into the array when it is cleared
 */
@@ -47,14 +47,17 @@ waitUntil {
 };
 
 if (_clearDroppedItems) then {
+
 	private _weaponHolders = BLWK_playAreaCenter nearObjects ["weaponHolder",250];
-	_weaponHolders = _weaponHolders select {typeOf _x == "groundWeaponHolder" AND {!(_x in BLWK_spawnedLoot)}};
+	_weaponHolders = _weaponHolders select {typeOf _x == "groundWeaponHolder" AND {!(_x in BLWK_lootHolders)}};
+
 	if !(_weaponHolders isEqualTo []) then {
 		_weaponHolders apply {
 			deleteVehicle _x;
 		};
 		sleep 1;
 	};
+
 };
 
 // update wave number

--- a/Headers/descriptionEXT/missionParams.hpp
+++ b/Headers/descriptionEXT/missionParams.hpp
@@ -275,6 +275,13 @@ class BLWK_playAreaRadius
 	texts[] = {"(50m) Tiny", "(100m) Small", "(150m) Normal", "(200m) Large", "(250m) Huge"};
 	GET_DEFAULT_PARAM(BLWK_playAreaRadius,150)
 };
+class BLWK_maxLootSpawns
+{
+	title = "Max Number Of Loot Spawns";
+	values[] = {100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000};
+	texts[] = {"100","200","300","400","500","600","700","800","900","1000","1100","1200", "1300", "1400", "1500", "1600", "1700", "1800", "1900", "2000"};
+	GET_DEFAULT_PARAM(BLWK_maxLootSpawns,1000)
+};
 class BLWK_minNumberOfHousesInArea
 {
 	title = "Minimum number of buildings in the play area radius";


### PR DESCRIPTION
- Changed `BLWK_spawnedLoot` to `BLWK_lootHolders`

- Optimized `BLWK_fnc_spawnLoot`
  - Cached all terrain buildings in play area
  - Removed unique items (e.g. loot reveal box) from `BLWK_lootHolders`
  - Made loot holders only spawn when there is not the maximum possible amount (per area settings and max allowed setting) of holders in the area

- Changed weapon holders to class `GroundWeaponHolder_Scripted`. This is required for how the function is written (`WeaponHolderSimulated` would delete automatically when empty and `WeaponHolderSimulated_scripted` has too much of a performance hit)