### PR TITLE
0.9.2 Release Build

### DIFF
--- a/Functions/Waves/fn_spawnLoot.sqf
+++ b/Functions/Waves/fn_spawnLoot.sqf
@@ -84,7 +84,7 @@ private _exit = false;
 			if (count _sortedPositions >= MAX_SPAWNS_PLUS_UNIQUES) then {_exit = true; break};
 
 			if (_forEachIndex isEqualTo 0 OR {(_forEachIndex mod BLWK_loot_roomDistribution) isEqualTo 0}) then {
-				_sortedPositions pushBack (_x vectorAdd [0,0,LOOT_HOLDER_Z_BUFFER]);
+				_sortedPositions pushBack (AGLToASL (_x vectorAdd [0,0,LOOT_HOLDER_Z_BUFFER]));
 			};
 		} forEach _buildingsPositions;
 	};
@@ -312,7 +312,7 @@ private _fn_addLoot = {
 		_selectedItemClass = selectRandom BLWK_loot_weaponClasses;
 		_magazineClass = [_selectedItemClass] call _fn_findAMagazine;
 		// if weapon has mags capable of spawning
-		if (_magazineClass != "") then {
+		if (_magazineClass isNotEqualTo "") then {
 			_holder addMagazineCargoGlobal [_magazineClass,round random [1,2,3]];
 		};
 
@@ -328,7 +328,7 @@ private _fn_addLoot = {
 };
 
 BLWK_lootHolders apply {
-	_x setPos (call _fn_getASpawnPosition);
+	_x setPosASL (call _fn_getASpawnPosition);
 
 	private _primaryLootClass = [_x] call _fn_addLoot;
 	// used for displaying loot markers in BLWK_fnc_createLootMarkers

--- a/KISKA Systems/KISKA Parameter Menu/Functions/OnLoad/fn_paramsMenu_onLoad_saveAndLoadControls.sqf
+++ b/KISKA Systems/KISKA Parameter Menu/Functions/OnLoad/fn_paramsMenu_onLoad_saveAndLoadControls.sqf
@@ -56,9 +56,11 @@ _saveButton_ctrl ctrlAddEventHandler ["ButtonClick",{
 
 private _saveAsButton_ctrl = _paramsMenuDisplay displayCtrl PARAMS_MENU_SAVEAS_BUTTON_IDC;
 _saveAsButton_ctrl ctrlAddEventHandler ["ButtonClick",{
+    params ["_saveAsButton_ctrl"];
 
-    private _paramsMenuDisplay = localNamespace getVariable [PARAMS_MENU_DISPLAY_VAR_STR,displayNull];
-    private _profileName = ctrlText (_paramsMenuDisplay displayCtrl PARAMS_MENU_SAVEAS_EDIT_BOX_IDC);
+    private _paramsMenuDisplay = GET_PARAMS_MENU_DISPLAY;
+    private _saveAsEditBox_ctrl = _paramsMenuDisplay displayCtrl PARAMS_MENU_SAVEAS_EDIT_BOX_IDC;
+    private _profileName = ctrlText _saveAsEditBox_ctrl;
 
     if (_profileName isNotEqualTo "") then {
         private _savedProfilesHash = GET_PARAMS_SAVED_PROFILES_HASHMAP;
@@ -68,12 +70,22 @@ _saveAsButton_ctrl ctrlAddEventHandler ["ButtonClick",{
         profilenamespace setVariable [GET_PARAMS_PROFILE_VAR_STR,_savedProfilesHash];
         saveProfileNamespace;
 
-        [_paramsMenuDisplay displayCtrl PARAMS_MENU_LOAD_COMBO_IDC] spawn KISKA_fnc_paramsMenu_updateLoadCombo;
+        private _loadCombo_ctrl = _paramsMenuDisplay displayCtrl PARAMS_MENU_LOAD_COMBO_IDC;
+        private _profiles = (keys _savedProfilesHash);
+        _profiles sort true;
+        private _index = _profiles find _profileName;
+        [_paramsMenuDisplay displayCtrl PARAMS_MENU_LOAD_COMBO_IDC,_index] spawn KISKA_fnc_paramsMenu_updateLoadCombo;
+
         ["Saved profile: " + _profileName] call KISKA_fnc_paramsMenu_logMessage;
+
+        _saveAsEditBox_ctrl ctrlSetText "";
+
     } else {
         ["You must enter a profile name"] call KISKA_fnc_paramsMenu_logMessage;
 
     };
+
+
 }];
 
 
@@ -139,9 +151,11 @@ _deleteButton_ctrl ctrlAddEventHandler ["ButtonClick",{
         saveProfileNamespace;
 
         [_loadCombo_ctrl] spawn KISKA_fnc_paramsMenu_updateLoadCombo;
-        ["Saved profile: " + _profileName] call KISKA_fnc_paramsMenu_logMessage;
+        ["Deleted profile: " + _profileName] call KISKA_fnc_paramsMenu_logMessage;
+
     } else {
         ["No valid profile selected for deletetion..."] call KISKA_fnc_paramsMenu_logMessage;
+
     };
 }];
 


### PR DESCRIPTION
FIXED: Switched to PositionASL instead of AGL when spawning loot to keep positions from being wildly incorrect
FIXED: Mission parameter menu prints "Saved Profile:" after deleting a profile

CHANGED: Save As edit box will now clear out after completing a save
CHANGED: Mission parameter menu will now switch the Saved Profile combo box to the newly saved profile after using Save As function

