### PR TITLE
New Enemy Spawn Direction Option

### DIFF
--- a/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
+++ b/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
@@ -83,12 +83,13 @@ private _fn_selectEnemyType = {
 
 // cache AI spawn info for queue
 private ["_spawnPositionTemp","_typeTemp"];
-if(!BLWK_multipleEnemyDirections) then {
-_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
-};
-for "_i" from 1 to _totalNumEnemiesToSpawnDuringWave do {
-	if(BLWK_multipleEnemyDirections) then{
+if (!BLWK_multipleEnemyPositions) then {
 	_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
+};
+
+for "_i" from 1 to _totalNumEnemiesToSpawnDuringWave do {
+	if (BLWK_multipleEnemyPositions) then {
+		_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
 	};
 	_typeTemp = call _fn_selectEnemyType;
 

--- a/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
+++ b/Functions/Wave Type Libraries/Standard Wave Library/fn_createStdWaveInfantry.sqf
@@ -83,8 +83,13 @@ private _fn_selectEnemyType = {
 
 // cache AI spawn info for queue
 private ["_spawnPositionTemp","_typeTemp"];
+if(!BLWK_multipleEnemyDirections) then {
+_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
+};
 for "_i" from 1 to _totalNumEnemiesToSpawnDuringWave do {
+	if(BLWK_multipleEnemyDirections) then{
 	_spawnPositionTemp = selectRandom BLWK_infantrySpawnPositions;
+	};
 	_typeTemp = call _fn_selectEnemyType;
 
 	[STANDARD_ENEMY_INFANTRY_QUEUE,_typeTemp,_spawnPositionTemp] call BLWK_fnc_addToQueue;

--- a/KISKA Systems/KISKA Parameter Menu/Headers/missionParams.hpp
+++ b/KISKA Systems/KISKA Parameter Menu/Headers/missionParams.hpp
@@ -1076,9 +1076,10 @@ class KISKA_missionParams
 			title = "Randomize Hostile Weapons";
 			default = DEFAULT_FALSE;
 		};
-		class BLWK_multipleEnemyDirections : yes_no_paramBase
+		class BLWK_multipleEnemyPositions : yes_no_paramBase
 		{
-			title = "Multiple Enemy Spawn Directions";
+			title = "Multiple Enemy Infantry Spawn Positions";
+			tooltip = "Enemies will spawn at a single (random) position or at several different random positions";
 			default = DEFAULT_TRUE;
 		};
 		class BLWK_maxPistolOnlyWaves : sliderParamBase

--- a/KISKA Systems/KISKA Parameter Menu/Headers/missionParams.hpp
+++ b/KISKA Systems/KISKA Parameter Menu/Headers/missionParams.hpp
@@ -1076,6 +1076,11 @@ class KISKA_missionParams
 			title = "Randomize Hostile Weapons";
 			default = DEFAULT_FALSE;
 		};
+		class BLWK_multipleEnemyDirections : yes_no_paramBase
+		{
+			title = "Multiple Enemy Spawn Directions";
+			default = DEFAULT_TRUE;
+		};
 		class BLWK_maxPistolOnlyWaves : sliderParamBase
 		{
 			title = "Hostiles only use pistols until wave";


### PR DESCRIPTION
* Added menu option to select between one random enemy spawn point, or multiple. Adds the feeling of a coordinated enemy attack from a single direction.

A very simple addition. Friends and I have been having fun keeping our eyes peeled for the enemy attack direction, and then positioning ourselves to try and repel the advance. It has a fun feeling to it, also keep an eye out for the bots trying to flank your position.