### PR TITLE
Fix speed typo

### DIFF
--- a/Functions/AI Pathing/fn_pathing_collisionLoop.sqf
+++ b/Functions/AI Pathing/fn_pathing_collisionLoop.sqf
@@ -66,7 +66,7 @@ while {BLWK_doDetectCollision AND {alive _unit}} do {
 
 				_unitGroup setCombatMode "BLUE";
 				_unitGroup setBehaviour "SAFE";
-				_unitGroup setSpeeedMode "FULL";
+				_unitGroup setSpeedMode "FULL";
 				_unit disableAI "TARGET";
 				_unit disableAI "AUTOTARGET";
 


### PR DESCRIPTION
Closes #597

Fixes misspelled `setSpeedMode`, which also fixes the error when the mission starts.