### PR TITLE
Add faction dependencies

### DIFF
--- a/Functions/KISKA Parameter Functions/fn_KISKAParams_populateFactionList.sqf
+++ b/Functions/KISKA Parameter Functions/fn_KISKAParams_populateFactionList.sqf
@@ -24,13 +24,20 @@ private _listOfNames = localNamespace getVariable ["BLWK_factionNames",[]];
 if (_listOfNames isEqualTo []) then {
 
     private _factionConfigsUnsorted = "true" configClasses (missionConfigFile >> "BLWK_factions");
+    private _mods = getLoadedModsInfo apply { _x select 1 };
 
     private _name = "";
+    private _classNames = [];
+    private _classNameIntersection = [];
+    private _hasAllDependencies = false;
     private _factionConfigs = [];
     _factionConfigsUnsorted apply {
-    	_name = getText(_x >> "displayName");
+        _name = getText (_x >> "displayName");
+        _classNames = getArray (_x >> "dependencies");
+        _classNameIntersection = _mods arrayIntersect _classNames;
+        _hasAllDependencies = (count _classNameIntersection) == (count _classNames);
 
-        if (_name isNotEqualTo "") then {
+        if (_name isNotEqualTo "" and _hasAllDependencies) then {
             _factionConfigs pushBack _x;
             _listOfNames pushBack _name;
         };

--- a/Functions/KISKA Parameter Functions/fn_KISKAParams_populateFactionList.sqf
+++ b/Functions/KISKA Parameter Functions/fn_KISKAParams_populateFactionList.sqf
@@ -27,20 +27,34 @@ if (_listOfNames isEqualTo []) then {
     private _mods = getLoadedModsInfo apply { _x select 1 };
 
     private _name = "";
-    private _classNames = [];
-    private _classNameIntersection = [];
+    private _dependencies = [];
+    private _loadedDependencies = [];
     private _hasAllDependencies = false;
     private _factionConfigs = [];
+
     _factionConfigsUnsorted apply {
         _name = getText (_x >> "displayName");
-        _classNames = getArray (_x >> "dependencies");
-        _classNameIntersection = _mods arrayIntersect _classNames;
-        _hasAllDependencies = (count _classNameIntersection) == (count _classNames);
+        if (_name isNotEqualTo "") then {
 
-        if (_name isNotEqualTo "" and _hasAllDependencies) then {
-            _factionConfigs pushBack _x;
-            _listOfNames pushBack _name;
-        };
+            _dependencies = getArray (_x >> "dependencies");
+            if (_dependencies isNotEqualTo []) then {
+                _loadedDependencies = _mods arrayIntersect _dependencies;
+                _hasAllDependencies = (count _loadedDependencies) isEqualTo (count _dependencies);
+
+                if (_hasAllDependencies) then {
+                    _factionConfigs pushBack _x;
+                    _listOfNames pushBack _name;
+                };
+
+            } else {
+                // some players may have added custom factions in the past without this
+                // so add to the list if no dependencies are defined
+                _factionConfigs pushBack _x;
+                _listOfNames pushBack _name;
+
+            };
+        }
+
     };
 
     localNamespace setVariable ["BLWK_factionConfigs",_factionConfigs];

--- a/Headers/descriptionEXT/Faction Headers/3CB BAF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/3CB BAF Unit Table.hpp
@@ -1,5 +1,6 @@
 class 3CBBAF_Woodland_Base : NATO_pacific_faction
-{	
+{
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -41,7 +42,8 @@ class 3CBBAF_Woodland_Base : NATO_pacific_faction
 };
 
 class 3CBBAF_Desert_Base : NATO_faction
-{	
+{
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -84,6 +86,7 @@ class 3CBBAF_Desert_Base : NATO_faction
 
 class 3CBBAF_army_desert_faction : 3CBBAF_Desert_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Desert";
 	infantry[] = {
 		"UK3CB_BAF_MATC_DDPM", 
@@ -132,6 +135,7 @@ class 3CBBAF_army_desert_faction : 3CBBAF_Desert_Base
 };
 class 3CBBAF_army_artic_faction : 3CBBAF_Desert_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Artic";
 	infantry[] = {
 		"UK3CB_BAF_MATC_Arctic", 
@@ -179,6 +183,7 @@ class 3CBBAF_army_artic_faction : 3CBBAF_Desert_Base
 };
 class 3CBBAF_army_mtp_faction : 3CBBAF_Desert_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Multicam (MTP)";
 	infantry[] = {
 		"UK3CB_BAF_MATC_MTP", 
@@ -264,6 +269,7 @@ class 3CBBAF_army_mtp_faction : 3CBBAF_Desert_Base
 };
 class 3CBBAF_army_temperate_faction : 3CBBAF_Woodland_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Temperate";
 	infantry[] = {
 		"UK3CB_BAF_MATC_DPMT", 
@@ -313,6 +319,7 @@ class 3CBBAF_army_temperate_faction : 3CBBAF_Woodland_Base
 };
 class 3CBBAF_army_tropical_faction : 3CBBAF_Woodland_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Tropical";
 	infantry[] = {
 		"UK3CB_BAF_MATC_Tropical", 
@@ -362,6 +369,7 @@ class 3CBBAF_army_tropical_faction : 3CBBAF_Woodland_Base
 };
 class 3CBBAF_army_woodland_faction : 3CBBAF_Woodland_Base
 {
+	dependencies[] = { "@3CB BAF Equipment", "@3CB BAF Units", "@3CB BAF Vehicles", "@3CB BAF Weapons" };
 	displayName = "3CB-BAF - Army Woodland";
 	infantry[] = {
 		"UK3CB_BAF_MATC_DPMW", 

--- a/Headers/descriptionEXT/Faction Headers/Aegis Atlas Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Aegis Atlas Unit Table.hpp
@@ -1,5 +1,6 @@
 class AEGIS_ATLAS_germany_faction : NATO_pacific_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - Bundeswehr";
 
 	heavyCars[] = {
@@ -61,6 +62,7 @@ class AEGIS_ATLAS_germany_faction : NATO_pacific_faction
 
 class AEGIS_ATLAS_legion_faction : NATO_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - French Foreign Legion";
 
 	infantry[] = {
@@ -95,6 +97,7 @@ class AEGIS_ATLAS_legion_faction : NATO_faction
 
 class AEGIS_ATLAS_himf_faction : FIA_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - HIMF";
 
 	lightCars[] = {
@@ -118,6 +121,7 @@ class AEGIS_ATLAS_himf_faction : FIA_faction
 
 class AEGIS_ATLAS_belarus_faction : AEGIS_China_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - Belarus";
 
 	attackHelicopters[] = {
@@ -156,6 +160,7 @@ class AEGIS_ATLAS_belarus_faction : AEGIS_China_faction
 
 class AEGIS_ATLAS_viper_woodland_faction : VIPER_pacific_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - Viper (Woodland)";
 
 	infantry[] = {
@@ -171,6 +176,7 @@ class AEGIS_ATLAS_viper_woodland_faction : VIPER_pacific_faction
 
 class AEGIS_ATLAS_takistan_faction : AEGIS_Argana_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - Taskistani Army";
 
 	infantry[] = {
@@ -192,6 +198,7 @@ class AEGIS_ATLAS_takistan_faction : AEGIS_Argana_faction
 
 class AEGIS_ATLAS_idf_faction : NATO_faction
 {
+	dependencies[] = { "@Arma 3 Atlas" };
 	displayName = "Aegis Atlas - Israeli Defense Force";
 
 	heavyCars[] = {

--- a/Headers/descriptionEXT/Faction Headers/Aegis Marines Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Aegis Marines Unit Table.hpp
@@ -1,5 +1,6 @@
 class AEGIS_MARINE_desert_faction : NATO_faction
 {
+	dependencies[] = { "@Arma 3 Aegis - Marines" };
 	displayName = "Aegis Marines - Desert";
 
 	attackHelicopters[] = {
@@ -28,6 +29,7 @@ class AEGIS_MARINE_desert_faction : NATO_faction
 
 class AEGIS_MARINE_woodland_faction : NATO_pacific_faction
 {
+	dependencies[] = { "@Arma 3 Aegis - Marines" };
 	displayName = "Aegis Marines - Woodland";
 
 	attackHelicopters[] = {

--- a/Headers/descriptionEXT/Faction Headers/Aegis Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Aegis Unit Table.hpp
@@ -1,6 +1,7 @@
 // BAF Bases
 class AEGIS_BAF_base : NATO_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "";
 
 	heavyCars[] = {
@@ -24,6 +25,7 @@ class AEGIS_BAF_base : NATO_faction
 };
 class AEGIS_BAF_pacific_base : NATO_pacific_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "";
 	
 	heavyCars[] = {
@@ -38,6 +40,7 @@ class AEGIS_BAF_pacific_base : NATO_pacific_faction
 // BAF Factions
 class AEGIS_BAF_faction : AEGIS_BAF_base
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - British Armed Forces";
 
 	infantry[] = {
@@ -87,6 +90,7 @@ class AEGIS_BAF_faction : AEGIS_BAF_base
 
 class AEGIS_BAF_pacific_faction : AEGIS_BAF_pacific_base
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - British Armed Forces (Pacific)";
 
 	infantry[] = {
@@ -136,6 +140,7 @@ class AEGIS_BAF_pacific_faction : AEGIS_BAF_pacific_base
 
 class AEGIS_BAF_woodland_faction : AEGIS_BAF_pacific_base
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - British Armed Forces (Woodland)";
 
 	infantry[] = {
@@ -187,6 +192,7 @@ class AEGIS_BAF_woodland_faction : AEGIS_BAF_pacific_base
 // CTRG
 class AEGIS_CTRG_medit_faction : NATO_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - CTRG (Mediterranean)";
 
 	lightCars[] = {
@@ -201,6 +207,7 @@ class AEGIS_CTRG_medit_faction : NATO_faction
 // CSAT
 class AEGIS_Argana_faction : CSAT_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - CSAT Argana (Desert)";
 
 	casAircraft[] = {
@@ -226,6 +233,7 @@ class AEGIS_Argana_faction : CSAT_faction
 
 class AEGIS_China_faction : CSAT_pacific_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - China (CSAT Pacific)";
 
 	casAircraft[] = {
@@ -240,6 +248,7 @@ class AEGIS_China_faction : CSAT_pacific_faction
 
 class AEGIS_Iran_faction : CSAT_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - Iranian Armed Forces (CSAT Arid)";
 
 	casAircraft[] = {
@@ -254,6 +263,7 @@ class AEGIS_Iran_faction : CSAT_faction
 
 class AEGIS_Russia_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - Russia";
 
 	lightCars[] = {
@@ -346,6 +356,7 @@ class AEGIS_Russia_faction
 
 class AEGIS_Russia_arid_faction : AEGIS_Russia_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - Russia (Arid)";
 
 	cargoAircraft[] = {
@@ -400,6 +411,7 @@ class AEGIS_Russia_arid_faction : AEGIS_Russia_faction
 
 class AEGIS_AAF_faction : AAF_faction
 {
+	dependencies[] = { "@Arma 3 Aegis" };
 	displayName = "Aegis - AAF";
 
 	cargoAircraft[] = {

--- a/Headers/descriptionEXT/Faction Headers/CSAT Modification Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/CSAT Modification Unit Table.hpp
@@ -1,5 +1,6 @@
 class TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Arid";
 
 	lightCars[] = {
@@ -86,6 +87,7 @@ class TEC_Iran_Arid_faction
 
 class TEC_Iran_arid_CBRN_faction : TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Arid (CBRN)";
 
 	infantry[] = {
@@ -121,6 +123,7 @@ class TEC_Iran_arid_CBRN_faction : TEC_Iran_Arid_faction
 
 class TEC_Iran_Semiarid_faction : TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Semiarid";
 
 	infantry[] = {
@@ -155,6 +158,7 @@ class TEC_Iran_Semiarid_faction : TEC_Iran_Arid_faction
 
 class TEC_Iran_urban_faction : TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Urban";
 
 	transportHelicopters[] = {
@@ -201,6 +205,7 @@ class TEC_Iran_urban_faction : TEC_Iran_Arid_faction
 
 class TEC_Iran_SF_Arid_faction : TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Special Forces (Arid)";
 
 	infantry[] = {
@@ -233,6 +238,7 @@ class TEC_Iran_SF_Arid_faction : TEC_Iran_Arid_faction
 
 class TEC_Iran_Viper_Arid_faction : TEC_Iran_Arid_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Viper (Arid)";
 
 	infantry[] = {
@@ -251,6 +257,7 @@ class TEC_Iran_Viper_Arid_faction : TEC_Iran_Arid_faction
 
 class TEC_Iran_WDL_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Woodland";
 
 	lightCars[] = {
@@ -337,6 +344,7 @@ class TEC_Iran_WDL_faction
 
 class TEC_Iran_WDL_CBRN_faction : TEC_Iran_WDL_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Woodland (CBRN)";
 
 	infantry[] = {
@@ -371,6 +379,7 @@ class TEC_Iran_WDL_CBRN_faction : TEC_Iran_WDL_faction
 
 class TEC_Iran_SF_WDL_faction : TEC_Iran_WDL_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Special Forces (Woodland)";
 
 	infantry[] = {
@@ -404,6 +413,7 @@ class TEC_Iran_SF_WDL_faction : TEC_Iran_WDL_faction
 
 class TEC_Iran_Viper_WDL_faction : TEC_Iran_WDL_faction
 {
+	dependencies[] = { "@The CSAT Modification Project" };
 	displayName = "CSAT Modification Project - Iran Viper (Woodland)";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/CUP Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/CUP Unit Table.hpp
@@ -1,5 +1,6 @@
 class CUP_ACR_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Army of the Czech Republic (Desert)";
 
 	lightCars[] = {
@@ -62,6 +63,7 @@ class CUP_ACR_DES_faction
 
 class CUP_ACR_WDL_faction : CUP_ACR_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Army of the Czech Republic (Woodland)";
 
 	lightCars[] = {
@@ -105,6 +107,7 @@ class CUP_ACR_WDL_faction : CUP_ACR_DES_faction
 
 class CUP_ACR_SF_DES_faction : CUP_ACR_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Army of the Czech Republic Special Forces (Desert)";
 
 	infantry[] = {
@@ -120,6 +123,7 @@ class CUP_ACR_SF_DES_faction : CUP_ACR_DES_faction
 
 class CUP_ACR_SF_WDL_faction : CUP_ACR_WDL_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Army of the Czech Republic Special Forces (Woodland)";
 
 	infantry[] = {
@@ -135,6 +139,7 @@ class CUP_ACR_SF_WDL_faction : CUP_ACR_WDL_faction
 
 class CUP_BAF_MTP_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - British Armed Forces (Multicam)";
 
 	lightCars[] = {
@@ -231,6 +236,7 @@ class CUP_BAF_MTP_faction
 
 class CUP_BAF_DES_faction : CUP_BAF_MTP_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - British Armed Forces (Desert)";
 
 	infantry[] = {
@@ -274,6 +280,7 @@ class CUP_BAF_DES_faction : CUP_BAF_MTP_faction
 
 class CUP_BAF_WDL_faction : CUP_BAF_MTP_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - British Armed Forces (Woodland)";
 
 	lightCars[] = {
@@ -349,6 +356,7 @@ class CUP_BAF_WDL_faction : CUP_BAF_MTP_faction
 
 class CUP_GER_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Bundeswehr (Desert)";
 
 	lightCars[] = {
@@ -404,6 +412,7 @@ class CUP_GER_DES_faction
 
 class CUP_GER_WDL_faction : CUP_GER_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Bundeswehr (Woodland)";
 
 	lightCars[] = {
@@ -449,6 +458,7 @@ class CUP_GER_WDL_faction : CUP_GER_DES_faction
 
 class CUP_GER_KSK_DES_faction : CUP_GER_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Bundeswehr KSK (Desert)";
 
 	infantry[] = {
@@ -476,6 +486,7 @@ class CUP_GER_KSK_DES_faction : CUP_GER_DES_faction
 
 class CUP_GER_KSK_WDL_faction : CUP_GER_WDL_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Bundeswehr KSK (Woodland)";
 
 	infantry[] = {
@@ -503,6 +514,7 @@ class CUP_GER_KSK_WDL_faction : CUP_GER_WDL_faction
 
 class CUP_CDF_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Chernarus Defense Forces (Desert)";
 
 	lightCars[] = {
@@ -562,6 +574,7 @@ class CUP_CDF_DES_faction
 
 class CUP_CDF_FST_faction : CUP_CDF_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Chernarus Defense Forces (Forest)";
 
 	infantry[] = {
@@ -587,6 +600,7 @@ class CUP_CDF_FST_faction : CUP_CDF_DES_faction
 
 class CUP_CDF_MNT_faction : CUP_CDF_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Chernarus Defense Forces (Mountain)";
 
 	infantry[] = {
@@ -612,6 +626,7 @@ class CUP_CDF_MNT_faction : CUP_CDF_DES_faction
 
 class CUP_CDF_SNW_faction : CUP_CDF_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Chernarus Defense Forces (Snow)";
 
 	infantry[] = {
@@ -637,6 +652,7 @@ class CUP_CDF_SNW_faction : CUP_CDF_DES_faction
 
 class CUP_HIL_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Horizon Islands Legion";
 
 	lightCars[] = {
@@ -687,6 +703,7 @@ class CUP_HIL_faction
 
 class CUP_HIL_RECON_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Horizon Islands Legion (Recon)";
 
 	infantry[] = {
@@ -705,6 +722,7 @@ class CUP_HIL_RECON_faction
 
 class CUP_HIL_RES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Horizon Islands Legion (Reservists)";
 
 	infantry[] = {
@@ -726,6 +744,7 @@ class CUP_HIL_RES_faction
 
 class CUP_HIL_SF_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Horizon Islands Legion (Special Forces)";
 
 	infantry[] = {
@@ -748,6 +767,7 @@ class CUP_HIL_SF_faction
 
 class CUP_USARMY_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	transportHelicopters[] = {
@@ -768,6 +788,7 @@ class CUP_USARMY_base
 
 class CUP_USARMY_DES_base : CUP_USARMY_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -807,6 +828,7 @@ class CUP_USARMY_DES_base : CUP_USARMY_base
 
 class CUP_USARMY_WDL_base : CUP_USARMY_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -846,6 +868,7 @@ class CUP_USARMY_WDL_base : CUP_USARMY_base
 
 class CUP_USARMY_OCP_DES_faction : CUP_USARMY_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army OCP (Desert)";
 
 	infantry[] = {
@@ -880,6 +903,7 @@ class CUP_USARMY_OCP_DES_faction : CUP_USARMY_DES_base
 
 class CUP_USARMY_OCP_WDL_faction : CUP_USARMY_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army OCP (Woodland)";
 
 	infantry[] = {
@@ -914,6 +938,7 @@ class CUP_USARMY_OCP_WDL_faction : CUP_USARMY_WDL_base
 
 class CUP_USARMY_OEFCP_DES_faction : CUP_USARMY_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army OEF-CP (Desert)";
 
 	infantry[] = {
@@ -948,6 +973,7 @@ class CUP_USARMY_OEFCP_DES_faction : CUP_USARMY_DES_base
 
 class CUP_USARMY_OEFCP_WDL_faction : CUP_USARMY_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army OEF-CP (Woodland)";
 
 	infantry[] = {
@@ -982,6 +1008,7 @@ class CUP_USARMY_OEFCP_WDL_faction : CUP_USARMY_WDL_base
 
 class CUP_USARMY_SF_DES_faction : CUP_USARMY_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army Special Forces (Desert)";
 
 	transportHelicopters[] = {
@@ -1008,6 +1035,7 @@ class CUP_USARMY_SF_DES_faction : CUP_USARMY_DES_base
 
 class CUP_USARMY_SF_WDL_faction : CUP_USARMY_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army Special Forces (Woodland)";
 
 	transportHelicopters[] = {
@@ -1034,6 +1062,7 @@ class CUP_USARMY_SF_WDL_faction : CUP_USARMY_WDL_base
 
 class CUP_USARMY_UCP_DES_faction : CUP_USARMY_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army UCP (Desert)";
 
 	infantry[] = {
@@ -1068,6 +1097,7 @@ class CUP_USARMY_UCP_DES_faction : CUP_USARMY_DES_base
 
 class CUP_USARMY_UCP_WDL_faction : CUP_USARMY_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - US Army UCP (Woodland)";
 
 	infantry[] = {
@@ -1102,6 +1132,7 @@ class CUP_USARMY_UCP_WDL_faction : CUP_USARMY_WDL_base
 
 class CUP_USMC_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	transportHelicopters[] = {
@@ -1126,6 +1157,7 @@ class CUP_USMC_base
 
 class CUP_USMC_DES_base : CUP_USMC_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -1157,6 +1189,7 @@ class CUP_USMC_DES_base : CUP_USMC_base
 
 class CUP_USMC_WDL_base : CUP_USMC_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -1189,6 +1222,7 @@ class CUP_USMC_WDL_base : CUP_USMC_base
 
 class CUP_USMC_DES_faction : CUP_USMC_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC (Desert)";
 
 	infantry[] = {
@@ -1216,6 +1250,7 @@ class CUP_USMC_DES_faction : CUP_USMC_DES_base
 
 class CUP_USMC_WDL_faction : CUP_USMC_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC (Woodland)";
 
 	infantry[] = {
@@ -1242,6 +1277,7 @@ class CUP_USMC_WDL_faction : CUP_USMC_WDL_base
 
 class CUP_USMC_FR_DES_faction : CUP_USMC_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC Force Recon (Desert)";
 
 	infantry[] = {
@@ -1262,6 +1298,7 @@ class CUP_USMC_FR_DES_faction : CUP_USMC_DES_base
 
 class CUP_USMC_FR_WDL_faction : CUP_USMC_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC Force Recon (Woodland)";
 
 	infantry[] = {
@@ -1282,6 +1319,7 @@ class CUP_USMC_FR_WDL_faction : CUP_USMC_WDL_base
 
 class CUP_USMC_FROG_DES_faction : CUP_USMC_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC FROG (Desert)";
 
 	infantry[] = {
@@ -1302,6 +1340,7 @@ class CUP_USMC_FROG_DES_faction : CUP_USMC_DES_base
 
 class CUP_USMC_FROG_WDL_faction : CUP_USMC_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - USMC FROG (Woodland)";
 
 	infantry[] = {
@@ -1326,6 +1365,7 @@ class CUP_USMC_FROG_WDL_faction : CUP_USMC_WDL_base
 
 class CUP_USMC_MARSOC_DES_faction : CUP_USMC_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - MARSOC (Desert)";
 
 	infantry[] = {
@@ -1352,6 +1392,7 @@ class CUP_USMC_MARSOC_DES_faction : CUP_USMC_DES_base
 
 class CUP_USMC_MARSOC_WDL_faction : CUP_USMC_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - MARSOC (Woodland)";
 
 	infantry[] = {
@@ -1378,6 +1419,7 @@ class CUP_USMC_MARSOC_WDL_faction : CUP_USMC_WDL_base
 
 class CUP_AFRF_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -1414,6 +1456,7 @@ class CUP_AFRF_base
 
 class CUP_AFRF_WDL_base : CUP_AFRF_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightArmor[] = {
@@ -1430,6 +1473,7 @@ class CUP_AFRF_WDL_base : CUP_AFRF_base
 
 class CUP_AFRF_DES_base : CUP_AFRF_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightArmor[] = {
@@ -1445,6 +1489,7 @@ class CUP_AFRF_DES_base : CUP_AFRF_base
 
 class CUP_AFRF_SNW_base : CUP_AFRF_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightArmor[] = {
@@ -1456,6 +1501,7 @@ class CUP_AFRF_SNW_base : CUP_AFRF_base
 
 class CUP_AFRF_ARID_base : CUP_AFRF_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightArmor[] = {
@@ -1469,6 +1515,7 @@ class CUP_AFRF_ARID_base : CUP_AFRF_base
 
 class CUP_AFRF_MSV_MODERN_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (MSV - Modern - EMR)";
 
 	infantry[] = {
@@ -1496,6 +1543,7 @@ class CUP_AFRF_MSV_MODERN_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_VDV_MODERN_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (VDV - Modern - EMR)";
 
 	infantry[] = {
@@ -1523,6 +1571,7 @@ class CUP_AFRF_VDV_MODERN_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_MSV_EMR_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (MSV - EMR)";
 
 	infantry[] = {
@@ -1550,6 +1599,7 @@ class CUP_AFRF_MSV_EMR_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_MSV_TTSKO_faction : CUP_AFRF_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (MSV - TTsKO)";
 
 	infantry[] = {
@@ -1577,6 +1627,7 @@ class CUP_AFRF_MSV_TTSKO_faction : CUP_AFRF_DES_base
 
 class CUP_AFRF_MSV_VSR93_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (MSV - VSR-93)";
 
 	infantry[] = {
@@ -1602,6 +1653,7 @@ class CUP_AFRF_MSV_VSR93_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_MVD_faction : CUP_AFRF_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (MVD)";
 
 	infantry[] = {
@@ -1617,6 +1669,7 @@ class CUP_AFRF_MVD_faction : CUP_AFRF_DES_base
 
 class CUP_AFRF_RATNIK_AUT_faction : CUP_AFRF_ARID_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Ratnik - Autumn)";
 
 	infantry[] = {
@@ -1651,6 +1704,7 @@ class CUP_AFRF_RATNIK_AUT_faction : CUP_AFRF_ARID_base
 
 class CUP_AFRF_RATNIK_BD_faction : CUP_AFRF_ARID_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Ratnik - Beige Digital)";
 
 	infantry[] = {
@@ -1685,6 +1739,7 @@ class CUP_AFRF_RATNIK_BD_faction : CUP_AFRF_ARID_base
 
 class CUP_AFRF_RATNIK_DES_faction : CUP_AFRF_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Ratnik - Desert)";
 
 	infantry[] = {
@@ -1719,6 +1774,7 @@ class CUP_AFRF_RATNIK_DES_faction : CUP_AFRF_DES_base
 
 class CUP_AFRF_RATNIK_SUM_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Ratnik - Summer)";
 
 	infantry[] = {
@@ -1753,6 +1809,7 @@ class CUP_AFRF_RATNIK_SUM_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_RATNIK_SNW_faction : CUP_AFRF_SNW_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Ratnik - Winter)";
 
 	infantry[] = {
@@ -1787,6 +1844,7 @@ class CUP_AFRF_RATNIK_SNW_faction : CUP_AFRF_SNW_base
 
 class CUP_AFRF_SPETSNAZ_AUT_faction : CUP_AFRF_ARID_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Spetsnaz - Autumn)";
 
 	infantry[] = {
@@ -1805,6 +1863,7 @@ class CUP_AFRF_SPETSNAZ_AUT_faction : CUP_AFRF_ARID_base
 
 class CUP_AFRF_SPETSNAZ_SUM_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (Spetsnaz - Summer)";
 
 	infantry[] = {
@@ -1823,6 +1882,7 @@ class CUP_AFRF_SPETSNAZ_SUM_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_VDV_EMR_faction : CUP_AFRF_WDL_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (VDV - EMR)";
 
 	infantry[] = {
@@ -1850,6 +1910,7 @@ class CUP_AFRF_VDV_EMR_faction : CUP_AFRF_WDL_base
 
 class CUP_AFRF_VDV_TTSKO_faction : CUP_AFRF_DES_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Armed Forces of the Russian Federation (VDV - TTsKO)";
 
 	infantry[] = {
@@ -1877,6 +1938,7 @@ class CUP_AFRF_VDV_TTSKO_faction : CUP_AFRF_DES_base
 
 class CUP_CHDKZ_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Chernarus Movement of the Red Star";
 
 	lightCars[] = {
@@ -1949,6 +2011,7 @@ class CUP_CHDKZ_faction
 
 class CUP_SLA_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "";
 
 	lightCars[] = {
@@ -1990,6 +2053,7 @@ class CUP_SLA_base
 
 class CUP_SLA_FOREST_faction : CUP_SLA_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Sahrani Liberation Army (Forest)";
 
 	infantry[] = {
@@ -2024,6 +2088,7 @@ class CUP_SLA_FOREST_faction : CUP_SLA_base
 
 class CUP_SLA_DESERT_faction : CUP_SLA_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Sahrani Liberation Army (Desert)";
 
 	infantry[] = {
@@ -2053,6 +2118,7 @@ class CUP_SLA_DESERT_faction : CUP_SLA_base
 
 class CUP_SLA_MILITIA_faction : CUP_SLA_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Sahrani Liberation Army (Militia)";
 
 	infantry[] = {
@@ -2075,6 +2141,7 @@ class CUP_SLA_MILITIA_faction : CUP_SLA_base
 
 class CUP_SLA_URBAN_faction : CUP_SLA_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Sahrani Liberation Army (Urban)";
 
 	infantry[] = {
@@ -2104,6 +2171,7 @@ class CUP_SLA_URBAN_faction : CUP_SLA_base
 
 class CUP_TKA_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Takistani Army";
 
 	lightCars[] = {
@@ -2181,6 +2249,7 @@ class CUP_TKA_faction
 
 class CUP_TKM_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Takistani Militia";
 
 	lightCars[] = {
@@ -2244,6 +2313,7 @@ class CUP_TKM_faction
 
 class CUP_PMC_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - ION PMC";
 
 	lightCars[] = {
@@ -2308,6 +2378,7 @@ class CUP_PMC_faction
 
 class CUP_PMC_ARTIC_faction : CUP_PMC_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - ION PMC (Artic)";
 
 	heavyCars[] = {
@@ -2342,6 +2413,7 @@ class CUP_PMC_ARTIC_faction : CUP_PMC_faction
 
 class CUP_NAPA_faction : CUP_CHDKZ_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - National Party of Chernarus";
 
 	lightCars[] = {
@@ -2404,6 +2476,7 @@ class CUP_NAPA_faction : CUP_CHDKZ_faction
 
 class CUP_RACS_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Royal Army Corps of Sahrani";
 
 	lightCars[] = {
@@ -2443,6 +2516,7 @@ class CUP_RACS_base
 };
 class CUP_RACS_DES_faction : CUP_RACS_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Royal Army Corps of Sahrani (Desert)";
 
 	infantry[] = {
@@ -2467,6 +2541,7 @@ class CUP_RACS_DES_faction : CUP_RACS_base
 };
 class CUP_RACS_JUNGLE_faction : CUP_RACS_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Royal Army Corps of Sahrani (Jungle)";
 
 	infantry[] = {
@@ -2491,6 +2566,7 @@ class CUP_RACS_JUNGLE_faction : CUP_RACS_base
 };
 class CUP_RACS_URBAN_faction : CUP_RACS_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Royal Army Corps of Sahrani (Urban)";
 
 	infantry[] = {
@@ -2515,6 +2591,7 @@ class CUP_RACS_URBAN_faction : CUP_RACS_base
 };
 class CUP_RACS_WDL_faction : CUP_RACS_base
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Royal Army Corps of Sahrani (Woodland)";
 
 	infantry[] = {
@@ -2543,6 +2620,7 @@ class CUP_RACS_WDL_faction : CUP_RACS_base
 
 class CUP_TKL_faction : CUP_TKM_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - Takistani Locals";
 
 	infantry[] = {
@@ -2569,6 +2647,7 @@ class CUP_TKL_faction : CUP_TKM_faction
 
 class CUP_UN_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - United Nations (Desert)";
 
 	lightCars[] = {
@@ -2624,6 +2703,7 @@ class CUP_UN_DES_faction
 
 class CUP_UN_FOREST_faction : CUP_UN_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - United Nations (Forest)";
 
 	infantry[] = {
@@ -2645,6 +2725,7 @@ class CUP_UN_FOREST_faction : CUP_UN_DES_faction
 
 class CUP_UN_MNT_faction : CUP_UN_DES_faction
 {
+	dependencies[] = { "@CUP Units", "@CUP Vehicles", "@CUP Weapons" };
 	displayName = "CUP - United Nations (Mountain)";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/JTFS URF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/JTFS URF Unit Table.hpp
@@ -2,6 +2,7 @@
 
 class JTFS_URF_faction
 {
+	dependencies[] = { "???" }; // Couldn't find a matching mod on the workshop
 	displayName = "JTFS Armory - United Rebel Front"; 
 
 	//excluding JTFS_Crewman, JTFS_Pilot_01, JTFS_Pilot_02, JTFS_Officer_01, JTFS_Officer_02

--- a/Headers/descriptionEXT/Faction Headers/JTFS URF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/JTFS URF Unit Table.hpp
@@ -2,8 +2,8 @@
 
 class JTFS_URF_faction
 {
-	dependencies[] = { "???" }; // Couldn't find a matching mod on the workshop
-	displayName = "JTFS Armory - United Rebel Front"; 
+	dependencies[] = { "@JTFS Armory" }; // Couldn't find a matching mod on the workshop
+	displayName = "JTFS Armory - United Rebel Front";
 
 	//excluding JTFS_Crewman, JTFS_Pilot_01, JTFS_Pilot_02, JTFS_Officer_01, JTFS_Officer_02
 	infantry[]={
@@ -52,8 +52,8 @@ class JTFS_URF_faction
 		"JTFS_Plane_Xian_inf", //VTOL transport, infantry variant. JTFS_Plane_Xian_vic for vics if we ever need it.
 		"JTFS_Heli_Mohawk"
 		//"JTFS_Pelican_unarmed" // prone to errors in flight
-		
-		 
+
+
 	};
 	// excluded are the armed pelican, falcon, hornet, and Xi'an transport (have you seen how much ordnance that thing carries??)
 	casAircraft[]={
@@ -63,7 +63,7 @@ class JTFS_URF_faction
 	attackHelicopters[]={
 		"JTFS_Heli_Kajman"
 	};
-	// maybe I'll reskin an equivalent for the rebels.. 
+	// maybe I'll reskin an equivalent for the rebels..
 	heavyGunships[]={
 	};
 };

--- a/Headers/descriptionEXT/Faction Headers/Max Terminator.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Max Terminator.hpp
@@ -1,5 +1,6 @@
 class Max_Terminator_Skynet_Army_faction
 {
+	dependencies[] = { "@Max_Terminator" };
 	displayName = "Max Terminator - Skynet Army";
 
 	heavyArmor[] = {
@@ -37,6 +38,7 @@ class Max_Terminator_Skynet_Army_faction
 
 class Max_Terminator_Skynet_Infiltration_faction
 {
+	dependencies[] = { "@Max_Terminator" };
 	displayName = "Max Terminator - Skynet Infiltration Units";
 
 	infantry[] = {
@@ -51,6 +53,7 @@ class Max_Terminator_Skynet_Infiltration_faction
 
 class Max_Terminator_Resistance_faction
 {
+	dependencies[] = { "@Max_Terminator" };
 	displayName = "Max Terminator - Resistance";
 
 	lightCars[] = {

--- a/Headers/descriptionEXT/Faction Headers/OPCAN Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/OPCAN Unit Table.hpp
@@ -1,5 +1,6 @@
 class OPCAN_CGC_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Colonial Guard Corps";
 	infantry[] = {
 		"LM_OPCAN_CGC_SL_WDL",
@@ -45,6 +46,7 @@ class OPCAN_CGC_faction
 
 class OPCAN_UNSC_ARMY_D_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Army Desert";
 
 	infantry[] = {
@@ -91,6 +93,7 @@ class OPCAN_UNSC_ARMY_D_faction
 
 class OPCAN_UNSC_ARMY_WDL_faction : OPCAN_CGC_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Army Woodland";
 
 	lightCars[] = {
@@ -125,6 +128,7 @@ class OPCAN_UNSC_ARMY_WDL_faction : OPCAN_CGC_faction
 
 class OPCAN_UNSC_ARMY_MIXED_faction : OPCAN_UNSC_ARMY_WDL_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Army Mixed";
 
 	infantry[] = {
@@ -148,6 +152,7 @@ class OPCAN_UNSC_ARMY_MIXED_faction : OPCAN_UNSC_ARMY_WDL_faction
 
 class OPCAN_UNSC_MARINE_WDL_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Marine Woodland";
 
 	lightCars[] = {
@@ -193,6 +198,7 @@ class OPCAN_UNSC_MARINE_WDL_faction
 
 class OPCAN_UNSC_MARINE_CEA_faction : OPCAN_UNSC_MARINE_WDL_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Marine CE-A";
 
 	infantry[] = {
@@ -214,6 +220,7 @@ class OPCAN_UNSC_MARINE_CEA_faction : OPCAN_UNSC_MARINE_WDL_faction
 
 class OPCAN_UNSC_MARINE_DES_faction : OPCAN_UNSC_MARINE_WDL_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Marine Desert";
 
 	infantry[] = {
@@ -235,6 +242,7 @@ class OPCAN_UNSC_MARINE_DES_faction : OPCAN_UNSC_MARINE_WDL_faction
 
 class OPCAN_UNSC_MARINE_INF_faction : OPCAN_UNSC_MARINE_WDL_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - UNSC Marine Infinite";
 
 	infantry[] = {
@@ -256,6 +264,7 @@ class OPCAN_UNSC_MARINE_INF_faction : OPCAN_UNSC_MARINE_WDL_faction
 
 class OPCAN_URA_faction : CSAT_pacific_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - United Rebel Army";
 
 	lightCars[] = {
@@ -299,6 +308,7 @@ class OPCAN_URA_faction : CSAT_pacific_faction
 
 class OPCAN_SU_faction : OPCAN_URA_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Secessionist Union";
 	lightCars[] = {
 		"LM_OPCAN_Rake_SU_HMG",
@@ -333,6 +343,7 @@ class OPCAN_SU_faction : OPCAN_URA_faction
 
 class OPCAN_KOSLOVICS_faction : OPCAN_URA_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Koslovics";
 
 	infantry[] = {
@@ -353,6 +364,7 @@ class OPCAN_KOSLOVICS_faction : OPCAN_URA_faction
 
 class OPCAN_FRIDENS_faction : OPCAN_URA_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Fridens";
 
 	lightCars[] = {
@@ -384,6 +396,7 @@ class OPCAN_FRIDENS_faction : OPCAN_URA_faction
 
 class OPCAN_FRIDENS_WDL_faction : OPCAN_FRIDENS_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Fridens Woodland";
 
 	infantry[] = {
@@ -404,6 +417,7 @@ class OPCAN_FRIDENS_WDL_faction : OPCAN_FRIDENS_faction
 
 class OPCAN_FRIDENS_DES_faction : OPCAN_FRIDENS_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Fridens Desert";
 
 	infantry[] = {
@@ -425,6 +439,7 @@ class OPCAN_FRIDENS_DES_faction : OPCAN_FRIDENS_faction
 
 class OPCAN_CMA_faction : OPCAN_CGC_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Colonial Military Authority";
 
 	infantry[] = {
@@ -445,6 +460,7 @@ class OPCAN_CMA_faction : OPCAN_CGC_faction
 
 class OPCAN_CPF_faction : OPCAN_CMA_faction
 {
+	dependencies[] = { "@OPCAN 3.0 By Wolf Of Tribute Modding (formerly LM)" };
 	displayName = "OPCAN - Colonial Police Force";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/OPTRE FC Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/OPTRE FC Unit Table.hpp
@@ -1,5 +1,6 @@
 class OPTRE_FC_COVENANT_faction
 {
+	dependencies[] = { "@Operation TREBUCHET First Contact" };
 	displayName = "OPTRE FC - Covenant";
 
 	infantry[] = {
@@ -25,6 +26,7 @@ class OPTRE_FC_COVENANT_faction
 
 class OPTRE_FC_MARINES_HCW_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET First Contact" };
 	displayName = "OPTRE FC - UNSC Marines HCW";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/OPTRE Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/OPTRE Unit Table.hpp
@@ -1,5 +1,6 @@
 class OPTRE_MARINES_faction
 {	
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Marines";
 
 	lightCars[] = {
@@ -54,6 +55,7 @@ class OPTRE_MARINES_faction
 
 class OPTRE_ODST_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - ODSTs";
 	lightCars[] = {
 		"OPTRE_M12_LRV_black",
@@ -88,6 +90,7 @@ class OPTRE_ODST_faction : OPTRE_MARINES_faction
 
 class OPTRE_ARMY_SNOW_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Snow";
 	lightCars[] = {
 		"OPTRE_M12_LRV_snow",
@@ -123,6 +126,7 @@ class OPTRE_ARMY_SNOW_faction : OPTRE_MARINES_faction
 
 class OPTRE_ARMY_DES_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Desert";
 	lightCars[] = {
 		"OPTRE_M12_LRV_tan",
@@ -165,6 +169,7 @@ class OPTRE_ARMY_DES_faction : OPTRE_MARINES_faction
 
 class OPTRE_ARMY_OLI_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Olive";
 
 	infantry[] = {
@@ -192,6 +197,7 @@ class OPTRE_ARMY_OLI_faction : OPTRE_MARINES_faction
 
 class OPTRE_ARMY_TROPICAL_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Tropical";
 
 	infantry[] = {
@@ -219,6 +225,7 @@ class OPTRE_ARMY_TROPICAL_faction : OPTRE_MARINES_faction
 
 class OPTRE_ARMY_URBAN_faction : OPTRE_ODST_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Urban";
 
 	infantry[] = {
@@ -246,6 +253,7 @@ class OPTRE_ARMY_URBAN_faction : OPTRE_ODST_faction
 
 class OPTRE_ARMY_WDL_faction : OPTRE_MARINES_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - UNSC Army Woodland";
 
 	infantry[] = {
@@ -273,6 +281,7 @@ class OPTRE_ARMY_WDL_faction : OPTRE_MARINES_faction
 
 class OPTRE_URF_faction : CSAT_pacific_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - United Rebel Front";
 
 	lightCars[] = {
@@ -314,6 +323,7 @@ class OPTRE_URF_faction : CSAT_pacific_faction
 
 class OPTRE_BJ_URBAN_faction : OPTRE_URF_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - Battle Jumpers Urban";
 	infantry[] = {
 		"OPTRE_Ins_BJ_Soldier_URB_Automatic_Rifleman",
@@ -330,6 +340,7 @@ class OPTRE_BJ_URBAN_faction : OPTRE_URF_faction
 
 class OPTRE_INSURGENTS_faction : FIA_faction
 {
+	dependencies[] = { "@Operation TREBUCHET" };
 	displayName = "OPTRE - Insurgents";
 	
 	lightCars[] = {

--- a/Headers/descriptionEXT/Faction Headers/Project OPFOR Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Project OPFOR Unit Table.hpp
@@ -1,5 +1,6 @@
 class PROJOP_AFRICAN_MILITIA_faction : RHSGREF_TLA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - African Militia";
 
 	lightCars[] = {
@@ -49,6 +50,7 @@ class PROJOP_AFRICAN_MILITIA_faction : RHSGREF_TLA_faction
 
 class PROJOP_BOKO_HAREM_faction : PROJOP_AFRICAN_MILITIA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Boko Harem";
 
 	infantry[] = {
@@ -71,6 +73,7 @@ class PROJOP_BOKO_HAREM_faction : PROJOP_AFRICAN_MILITIA_faction
 
 class PROJOP_CHDKZ_faction : RHSGREF_CHDKZ
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - ChDKZ";
 
 	lightArmor[] = {
@@ -101,6 +104,7 @@ class PROJOP_CHDKZ_faction : RHSGREF_CHDKZ
 
 class PROJOP_IRA_faction : RHSGREF_CHDKZ
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Irish Republic Army";
 
 	lightCars[] = {
@@ -127,6 +131,7 @@ class PROJOP_IRA_faction : RHSGREF_CHDKZ
 
 class PROJOP_ISIS_faction : RHSGREF_CHDKZ
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Islamic State";
 
 	lightCars[] = {
@@ -174,6 +179,7 @@ class PROJOP_ISIS_faction : RHSGREF_CHDKZ
 
 class PROJOP_KPA_faction : RHSGREF_CHDKZ
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Korean Peoples Army";
 
 
@@ -213,6 +219,7 @@ class PROJOP_KPA_faction : RHSGREF_CHDKZ
 
 class PROJOP_MEM_faction : PROJOP_KPA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Middle East Militia";
 
 	lightCars[] = {
@@ -246,6 +253,7 @@ class PROJOP_MEM_faction : PROJOP_KPA_faction
 
 class PROJOP_SLA_faction : RHSGREF_CDF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Sahrani Liberation Army";
 
 	lightCars[] = {
@@ -289,6 +297,7 @@ class PROJOP_SLA_faction : RHSGREF_CDF_faction
 
 class PROJOP_SAF_faction : PROJOP_SLA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Syrian Armed Forces";
 
 	heavyArmor[] = {
@@ -314,6 +323,7 @@ class PROJOP_SAF_faction : PROJOP_SLA_faction
 
 class PROJOP_TAF_faction : PROJOP_SLA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Takistan Armed Forces";
 
 	lightCars[] = {
@@ -358,6 +368,7 @@ class PROJOP_TAF_faction : PROJOP_SLA_faction
 
 class PROJOP_NAF_faction : PROJOP_TAF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Novorossiya Armed Forces";
 
 	lightCars[] = {
@@ -402,6 +413,7 @@ class PROJOP_NAF_faction : PROJOP_TAF_faction
 
 class PROJOP_ANA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Afghan National Army";
 
 	lightCars[] = {
@@ -460,6 +472,7 @@ class PROJOP_ANA_faction
 
 class PROJOP_ANP_faction : PROJOP_ANA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Afghan National Police";
 
 	lightCars[] = {
@@ -508,6 +521,7 @@ class PROJOP_ANP_faction : PROJOP_ANA_faction
 
 class PROJOP_CDF_faction : RHSGREF_CDF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - CDF";
 
 	infantry[] = {
@@ -531,6 +545,7 @@ class PROJOP_CDF_faction : RHSGREF_CDF_faction
 
 class PROJOP_HAF_faction : RHSGREF_HIDF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Hellnic Armed Forces";
 
 	infantry[] = {
@@ -549,6 +564,7 @@ class PROJOP_HAF_faction : RHSGREF_HIDF_faction
 
 class PROJOP_IAF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Iraqi Armed Forces";
 
 	lightCars[] = {
@@ -608,6 +624,7 @@ class PROJOP_IAF_faction
 
 class PROJOP_IAF_WDL_faction : PROJOP_IAF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Iraqi Armed Forces (Woodland)";
 
 	infantry[] = {
@@ -633,6 +650,7 @@ class PROJOP_IAF_WDL_faction : PROJOP_IAF_faction
 
 class PROJOP_IAF_SF_faction : PROJOP_IAF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Iraqi Special Forces";
 
 	infantry[] = {
@@ -653,6 +671,7 @@ class PROJOP_IAF_SF_faction : PROJOP_IAF_faction
 
 class PROJOP_KPF_faction : PROJOP_ANP_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Kurdish Peshmerga";
 
 	lightCars[] = {
@@ -685,6 +704,7 @@ class PROJOP_KPF_faction : PROJOP_ANP_faction
 
 class PROJOP_CNI_faction : RHSGREF_NAPA_MILITIA_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Chernarus National Insurgents";
 
 	infantry[] = {
@@ -707,6 +727,7 @@ class PROJOP_CNI_faction : RHSGREF_NAPA_MILITIA_faction
 
 class PROJOP_IRAN_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Iranian Armed Forces";
 
 	lightCars[] = {
@@ -764,6 +785,7 @@ class PROJOP_IRAN_faction
 
 class PROJOP_IRAN_SF_faction : PROJOP_IRAN_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Iranian Special Forces";
 
 	infantry[] = {
@@ -784,6 +806,7 @@ class PROJOP_IRAN_SF_faction : PROJOP_IRAN_faction
 
 class PROJOP_PMC_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - PMC";
 
 	lightCars[] = {
@@ -834,6 +857,7 @@ class PROJOP_PMC_faction
 
 class PROJOP_RACS_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Royal Army Corps of Sahrani";
 
 	lightCars[] = {
@@ -864,6 +888,7 @@ class PROJOP_RACS_faction
 
 class PROJOP_TURK_faction : PROJOP_CDF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Turkish Armed Forces";
 
 	infantry[] = {
@@ -883,6 +908,7 @@ class PROJOP_TURK_faction : PROJOP_CDF_faction
 
 class PROJOP_UAF_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Ukrainian Armed Forces";
 
 	lightCars[] = {
@@ -926,6 +952,7 @@ class PROJOP_UAF_faction
 
 class PROJOP_UVF_faction : PROJOP_PMC_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Ulseter Volunteer Force";
 
 	infantry[] = {
@@ -947,6 +974,7 @@ class PROJOP_UVF_faction : PROJOP_PMC_faction
 
 class PROJOP_ULT_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - Ultranationalists";
 
 	lightCars[] = {
@@ -996,6 +1024,7 @@ class PROJOP_ULT_faction
 
 class PROJOP_UN_faction
 {
+	dependencies[] = { "@Project OPFOR" };
 	displayName = "PROJECT OPFOR - United Nations";
 
 	lightCars[] = {

--- a/Headers/descriptionEXT/Faction Headers/RHS AFRF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/RHS AFRF Unit Table.hpp
@@ -1,5 +1,6 @@
 class RHSAFRF_MSV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia MSV (EMR)";
 	lightCars[] = {
 		"O_LSV_02_armed_black_F",
@@ -94,6 +95,7 @@ class RHSAFRF_MSV_EMR_faction
 
 class RHSAFRF_MSV_FLORA_faction : RHSAFRF_MSV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia MSV (Flora)";
 
 	infantry[] = {
@@ -117,6 +119,7 @@ class RHSAFRF_MSV_FLORA_faction : RHSAFRF_MSV_EMR_faction
 
 class RHSAFRF_VDV_EMR_faction : RHSAFRF_MSV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VDV (EMR)";
 
 	attackHelicopters[] = {
@@ -148,6 +151,7 @@ class RHSAFRF_VDV_EMR_faction : RHSAFRF_MSV_EMR_faction
 
 class RHSAFRF_VDV_EMR_faction_DES : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VDV (EMR-Des)";
 
 	infantry[] = {
@@ -173,6 +177,7 @@ class RHSAFRF_VDV_EMR_faction_DES : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VDV_FLORA_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VDV (Flora)";
 
 	infantry[] = {
@@ -195,6 +200,7 @@ class RHSAFRF_VDV_FLORA_faction : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VDV_MFLORA_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VDV (M-Flora)";
 
 	infantry[] = {
@@ -217,6 +223,7 @@ class RHSAFRF_VDV_MFLORA_faction : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VDV_RECON_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VDV (RECON)";
 
 	infantry[] = {
@@ -239,6 +246,7 @@ class RHSAFRF_VDV_RECON_faction : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VMF_RECON_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VMF (RECON)";
 
 	infantry[] = {
@@ -264,6 +272,7 @@ class RHSAFRF_VMF_RECON_faction : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VMF_FLORA_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VMF (Flora)";
 
 	infantry[] = {
@@ -287,6 +296,7 @@ class RHSAFRF_VMF_FLORA_faction : RHSAFRF_VDV_EMR_faction
 
 class RHSAFRF_VV_OSN_faction : RHSAFRF_VDV_EMR_faction
 {
+	dependencies[] = { "@RHSAFRF" };
 	displayName = "RHS AFRF - Russia VMF (OSN)";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/RHS ALL.hpp
+++ b/Headers/descriptionEXT/Faction Headers/RHS ALL.hpp
@@ -1,5 +1,6 @@
 class RHSALL_faction
 {
+	dependencies[] = { "@RHSAFRF", "@RHSGREF", "@RHSUSAF" };
 	displayName = "RHS ALL";
 	lightCars[] = {
 		"O_LSV_02_armed_black_F",

--- a/Headers/descriptionEXT/Faction Headers/RHS GREF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/RHS GREF Unit Table.hpp
@@ -1,5 +1,6 @@
 class RHSGREF_HIDF_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - Horizon Islands Defence Force";
 
 	lightCars[] = {
@@ -44,6 +45,7 @@ class RHSGREF_HIDF_faction
 //O_Heli_Attack_02_dynamicLoadout_black_F
 class RHSGREF_CDF_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - CDF";
 	
 	lightCars[] = {
@@ -111,6 +113,7 @@ class RHSGREF_CDF_faction
 
 class RHSGREF_CDF_GUARD_faction : RHSGREF_CDF_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - CDF Guard";
 
 	infantry[] = {
@@ -129,6 +132,7 @@ class RHSGREF_CDF_GUARD_faction : RHSGREF_CDF_faction
 
 class RHSGREF_CDF_PARA_faction : RHSGREF_CDF_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - CDF Paratroopers";
 
 	infantry[] = {
@@ -146,6 +150,7 @@ class RHSGREF_CDF_PARA_faction : RHSGREF_CDF_faction
 
 class RHSGREF_CHDKZ
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - ChDKZ";
 
 	lightCars[] = {
@@ -209,6 +214,7 @@ class RHSGREF_CHDKZ
 
 class RHSGREF_TLA_faction : RHSGREF_CHDKZ
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - Tanoan Liberation Army";
 
 	lightCars[] = {
@@ -241,6 +247,7 @@ class RHSGREF_TLA_faction : RHSGREF_CHDKZ
 
 class RHSGREF_NAPA_MILITIA_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - NAPA Militia";
 
 	lightCars[] = {
@@ -291,6 +298,7 @@ class RHSGREF_NAPA_MILITIA_faction
 
 class RHSGREF_NAPA_PARA_faction : RHSGREF_NAPA_MILITIA_faction
 {
+	dependencies[] = { "@RHSGREF" };
 	displayName = "RHS GREF - NAPA Paramilitary";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/RHS USAF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/RHS USAF Unit Table.hpp
@@ -1,5 +1,6 @@
 class RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Desert)";
 	lightCars[] = {
 		"rhsusf_m1025_d_m2",
@@ -102,6 +103,7 @@ class RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_DES_CRYE_faction : RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Desert CRYE)";
 
 	infantry[] = {
@@ -125,6 +127,7 @@ class RHSUSF_ARMY_DES_CRYE_faction : RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_WDL_faction : RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Woodland)";
 
 	lightCars[] = {
@@ -221,6 +224,7 @@ class RHSUSF_ARMY_WDL_faction : RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_WDL_CRYE_faction : RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Woodland CRYE)";
 
 	infantry[] = {
@@ -244,6 +248,7 @@ class RHSUSF_ARMY_WDL_CRYE_faction : RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_DES_UCP_faction : RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Desert UCP)";
 
 	infantry[] = {
@@ -278,6 +283,7 @@ class RHSUSF_ARMY_DES_UCP_faction : RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_WDL_UCP_faction : RHSUSF_ARMY_WDL_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Woodland UCP)";
 
 	infantry[] = {
@@ -312,6 +318,7 @@ class RHSUSF_ARMY_WDL_UCP_faction : RHSUSF_ARMY_WDL_faction
 
 class RHSUSF_ARMY_DES_UCP_CRYE_faction : RHSUSF_ARMY_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Desert UCP CRYE)";
 
 	infantry[] = {
@@ -336,6 +343,7 @@ class RHSUSF_ARMY_DES_UCP_CRYE_faction : RHSUSF_ARMY_DES_faction
 
 class RHSUSF_ARMY_WDL_UCP_CRYE_faction : RHSUSF_ARMY_WDL_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - US ARMY (Woodland UCP CRYE)";
 
 	infantry[] = {
@@ -360,6 +368,7 @@ class RHSUSF_ARMY_WDL_UCP_CRYE_faction : RHSUSF_ARMY_WDL_faction
 
 class RHSUSF_USMC_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - USMC Infantry (Desert)";
 
 	lightCars[] = {
@@ -434,6 +443,7 @@ class RHSUSF_USMC_DES_faction
 
 class RHSUSF_USMC_WDL_faction : RHSUSF_USMC_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - USMC Infantry (Woodland)";
 	lightCars[] = {
 		"rhsusf_m1025_w_s_m2",
@@ -494,6 +504,7 @@ class RHSUSF_USMC_WDL_faction : RHSUSF_USMC_DES_faction
 
 class RHSUSF_USMC_WDL_RECON_faction : RHSUSF_USMC_WDL_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - USMC RECON (Woodland)";
 
 	infantry[] = {
@@ -524,6 +535,7 @@ class RHSUSF_USMC_WDL_RECON_faction : RHSUSF_USMC_WDL_faction
 
 class RHSUSF_USMC_DES_RECON_faction : RHSUSF_USMC_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - USMC RECON (Desert)";
 
 	infantry[] = {
@@ -554,6 +566,7 @@ class RHSUSF_USMC_DES_RECON_faction : RHSUSF_USMC_DES_faction
 
 class RHSUSF_MARSOC_faction : RHSUSF_USMC_DES_faction
 {
+	dependencies[] = { "@RHSUSAF" };
 	displayName = "RHS USAF - MARSOC";
 	lightCars[] = {
 		"rhsusf_M1084A1R_SOV_M2_D_fmtv_socom",

--- a/Headers/descriptionEXT/Faction Headers/Russia 2035 Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Russia 2035 Unit Table.hpp
@@ -1,5 +1,6 @@
 class MIN_WDL
-{	
+{
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Woodland";
 
 	lightCars[] = {
@@ -60,6 +61,7 @@ class MIN_WDL
 
 class MIN_WDL_SF : MIN_WDL
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Woodland SF";
 
 	infantry[] = {
@@ -84,6 +86,7 @@ class MIN_WDL_SF : MIN_WDL
 
 class MIN_URB : MIN_WDL
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Urban";
 
 	infantry[] = {
@@ -110,6 +113,7 @@ class MIN_URB : MIN_WDL
 
 class MIN_DES : MIN_WDL
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Desert";
 
 	lightArmor[] = {
@@ -158,6 +162,7 @@ class MIN_DES : MIN_WDL
 
 class MIN_DES_SF : MIN_DES
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Desert SF";
 
 	infantry[] = {
@@ -182,6 +187,7 @@ class MIN_DES_SF : MIN_DES
 
 class MIN_WINT : MIN_DES
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Winter";
 
 	heavyCars[] = {
@@ -228,6 +234,7 @@ class MIN_WINT : MIN_DES
 
 class MIN_WINT_SF : MIN_WINT
 {
+	dependencies[] = { "@2035- Russian Armed Forces" };
 	displayName = "Russia 2035 - Winter SF";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/SOGPF Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/SOGPF Unit Table.hpp
@@ -1,5 +1,6 @@
 class SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - US Army";
 
     lightCars[] = {
@@ -68,6 +69,7 @@ class SOGPF_usArmy
 
 class SOGPF_usmc : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - USMC";
 
     heavyArmor[] = {
@@ -99,6 +101,7 @@ class SOGPF_usmc : SOGPF_usArmy
 
 class SOGPF_SEAL_det_bravo : SOGPF_usmc
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - SEALs Detachment Bravo";
 
     infantry[] = {
@@ -117,6 +120,7 @@ class SOGPF_SEAL_det_bravo : SOGPF_usmc
 
 class SOGPF_SEAL_team : SOGPF_usmc
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - SEAL Team";
 
     infantry[] = {
@@ -142,6 +146,7 @@ class SOGPF_SEAL_team : SOGPF_usmc
 
 class SOGPF_mikeForce : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Mike Force";
 
     infantry[] = {
@@ -172,6 +177,7 @@ class SOGPF_mikeForce : SOGPF_usArmy
 
 class SOGPF_usNavy : SOGPF_usmc
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - US Navy";
 
     infantry[] = {
@@ -189,6 +195,7 @@ class SOGPF_usNavy : SOGPF_usmc
 
 class SOGPF_macvSOG : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - MACV-SOG";
 
     transportHelicopters[] = {
@@ -233,6 +240,7 @@ class SOGPF_macvSOG : SOGPF_usArmy
 
 class SOGPF_lrrp : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Long Range Reconnaissance Patrol";
 
     infantry[] = {
@@ -250,6 +258,7 @@ class SOGPF_lrrp : SOGPF_usArmy
 
 class SOGPF_campStrikeForce : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Camp Strike Force";
 
     infantry[] = {
@@ -282,6 +291,7 @@ class SOGPF_campStrikeForce : SOGPF_usArmy
 
 class SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - NVA Dac Cong";
 
     lightCars[] = {
@@ -335,6 +345,7 @@ class SOGPF_NVA_dacCong
 
 class SOGPF_NVA_inf_65_field : SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - NVA 65 (Field)";
 
     infantry[] = {
@@ -359,6 +370,7 @@ class SOGPF_NVA_inf_65_field : SOGPF_NVA_dacCong
 
 class SOGPF_NVA_inf_65 : SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - NVA 65";
 
     infantry[] = {
@@ -384,6 +396,7 @@ class SOGPF_NVA_inf_65 : SOGPF_NVA_dacCong
 
 class SOGPF_NVA_field : SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - NVA (Field)";
 
     infantry[] = {
@@ -411,6 +424,7 @@ class SOGPF_NVA_field : SOGPF_NVA_dacCong
 
 class SOGPF_NVA : SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - NVA";
 
     infantry[] = {
@@ -438,6 +452,7 @@ class SOGPF_NVA : SOGPF_NVA_dacCong
 
 class SOGPF_VPN_marines : SOGPF_NVA_dacCong
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - VPN Marines";
 
     heavyCars[] = {
@@ -470,6 +485,7 @@ class SOGPF_VPN_marines : SOGPF_NVA_dacCong
 
 class SOGPF_VPN_navy : SOGPF_VPN_marines
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - VPN Navy";
 
     infantry[] = {
@@ -492,6 +508,7 @@ class SOGPF_VPN_navy : SOGPF_VPN_marines
 
 class SOGPF_VC_local : SOGPF_VPN_marines
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Viet Cong (Local)";
 
     heavyArmor[] = {
@@ -535,6 +552,7 @@ class SOGPF_VC_local : SOGPF_VPN_marines
 
 class SOGPF_VC_main : SOGPF_VPN_marines
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Viet Cong (Main Force)";
 
     infantry[] = {
@@ -560,6 +578,7 @@ class SOGPF_VC_main : SOGPF_VPN_marines
 
 class SOGPF_VC_regional : SOGPF_VPN_marines
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - Viet Cong (Regional)";
 
     infantry[] = {
@@ -583,6 +602,7 @@ class SOGPF_VC_regional : SOGPF_VPN_marines
 
 class SOGPF_ARVN : SOGPF_usArmy
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - ARVN";
 
     lightCars[] = {
@@ -630,6 +650,7 @@ class SOGPF_ARVN : SOGPF_usArmy
 
 class SOGPF_ARVN_lldb : SOGPF_ARVN
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - ARVN LLDB (Special Forces)";
 
     transportHelicopters[] = {
@@ -656,6 +677,7 @@ class SOGPF_ARVN_lldb : SOGPF_ARVN
 
 class SOGPF_ARVN_rangers : SOGPF_ARVN
 {
+    dependencies[] = { "VN" };
     displayName = "S.O.G. PF - ARVN Rangers";
 
     infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/There is Only War AM Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/There is Only War AM Unit Table.hpp
@@ -1,5 +1,6 @@
 class There_is_Only_War_Astra_Militarum_Cad_Combined
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Cadian (Combined)";
 
 	heavyArmor[] = {
@@ -121,6 +122,7 @@ class There_is_Only_War_Astra_Militarum_Cad_Combined
 
 class There_is_Only_War_Astra_Militarum_Cad_667th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Cadian 667th";
 
 	heavyArmor[] = {
@@ -163,6 +165,7 @@ class There_is_Only_War_Astra_Militarum_Cad_667th
 
 class There_is_Only_War_Astra_Militarum_Cad_700th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Cadian 700th";
 
 	heavyArmor[] = {
@@ -206,6 +209,7 @@ class There_is_Only_War_Astra_Militarum_Cad_700th
 
 class There_is_Only_War_Astra_Militarum_Cad_776th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Cadian 776th";
 
 	heavyArmor[] = {
@@ -248,6 +252,7 @@ class There_is_Only_War_Astra_Militarum_Cad_776th
 
 class There_is_Only_War_Astra_Militarum_Cad_836th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Cadian 836th";
 
 	heavyArmor[] = {
@@ -290,6 +295,7 @@ class There_is_Only_War_Astra_Militarum_Cad_836th
 
 class There_is_Only_War_Astra_Militarum_DKoK_Combined
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Death Korps of Krieg (Combined)";
 
 	heavyArmor[] = {
@@ -422,6 +428,7 @@ class There_is_Only_War_Astra_Militarum_DKoK_Combined
 
 class There_is_Only_War_Astra_Militarum_DKoK_1489th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Death Korps of Krieg 1489th";
 
 	heavyArmor[] = {
@@ -471,6 +478,7 @@ class There_is_Only_War_Astra_Militarum_DKoK_1489th
 
 class There_is_Only_War_Astra_Militarum_DKoK_1490th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Death Korps of Krieg 1490th";
 
 	heavyArmor[] = {
@@ -520,6 +528,7 @@ class There_is_Only_War_Astra_Militarum_DKoK_1490th
 
 class There_is_Only_War_Astra_Militarum_DKoK_1491th
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Death Korps of Krieg 1491st";
 
 	heavyArmor[] = {
@@ -569,6 +578,7 @@ class There_is_Only_War_Astra_Militarum_DKoK_1491th
 
 class There_is_Only_War_Astra_Militarum_DKoK_82nd
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Death Korps of Krieg 82nd";
 
 	heavyArmor[] = {
@@ -608,6 +618,7 @@ class There_is_Only_War_Astra_Militarum_DKoK_82nd
 
 class There_is_Only_War_Astra_Militarum_MIG_Combined
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Mordian Iron Guard (Combined)";
 
 	infantry[] = {
@@ -632,6 +643,7 @@ class There_is_Only_War_Astra_Militarum_MIG_Combined
 
 class There_is_Only_War_Astra_Militarum_MIG_Blue
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Mordian Iron Guard (Blue)";
 
 	infantry[] = {
@@ -648,6 +660,7 @@ class There_is_Only_War_Astra_Militarum_MIG_Blue
 
 class There_is_Only_War_Astra_Militarum_MIG_white
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum: Mordian Iron Guard (White)";
 
 	infantry[] = {
@@ -664,6 +677,7 @@ class There_is_Only_War_Astra_Militarum_MIG_white
 
 class There_is_Only_War_Astra_Militarum_C_PDF
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Cadminae PDF Forces";
 
 	infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/There is Only War Chaos Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/There is Only War Chaos Unit Table.hpp
@@ -1,5 +1,6 @@
 class There_is_Only_War_Chaos_SM_CC
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Cultists";
 
 	infantry[] = {
@@ -15,6 +16,7 @@ class There_is_Only_War_Chaos_SM_CC
 
 class There_is_Only_War_Chaos_SM_Combined
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines (Combined)";
 
 	heavyArmor[] = {
@@ -164,6 +166,7 @@ class There_is_Only_War_Chaos_SM_Combined
 
 class There_is_Only_War_Chaos_SM_AL
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Alpha Legion";
 
 	heavyArmor[] = {
@@ -194,6 +197,7 @@ class There_is_Only_War_Chaos_SM_AL
 
 class There_is_Only_War_Chaos_SM_BL
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Black Legion";
 
 	heavyArmor[] = {
@@ -223,6 +227,7 @@ class There_is_Only_War_Chaos_SM_BL
 
 class There_is_Only_War_Chaos_SM_DG
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Death Guard";
 
 	heavyArmor[] = {
@@ -252,6 +257,7 @@ class There_is_Only_War_Chaos_SM_DG
 
 class There_is_Only_War_Chaos_SM_EC
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Emperor's Children";
 
 	heavyArmor[] = {
@@ -281,6 +287,7 @@ class There_is_Only_War_Chaos_SM_EC
 
 class There_is_Only_War_Chaos_SM_IW
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Iron Warriors";
 
 	heavyArmor[] = {
@@ -310,6 +317,7 @@ class There_is_Only_War_Chaos_SM_IW
 
 class There_is_Only_War_Chaos_SM_NL
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Night Lords";
 
 	heavyArmor[] = {
@@ -339,6 +347,7 @@ class There_is_Only_War_Chaos_SM_NL
 
 class There_is_Only_War_Chaos_SM_TS
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: Thousand Sons";
 
 	heavyArmor[] = {
@@ -368,6 +377,7 @@ class There_is_Only_War_Chaos_SM_TS
 
 class There_is_Only_War_Chaos_SM_WB
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: World Bearers";
 
 	heavyArmor[] = {
@@ -397,6 +407,7 @@ class There_is_Only_War_Chaos_SM_WB
 
 class There_is_Only_War_Chaos_SM_WE
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Chaos Space Marines: World Eaters";
 
 	heavyArmor[] = {
@@ -426,6 +437,7 @@ class There_is_Only_War_Chaos_SM_WE
 
 class There_is_Only_War_Astra_Militarum_Chaos_Renegades
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Astra Militarum Renegades";
 
 	heavyArmor[] = {

--- a/Headers/descriptionEXT/Faction Headers/There is Only War SM Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/There is Only War SM Unit Table.hpp
@@ -1,5 +1,6 @@
 class There_is_Only_War_Adeptus_Astartes_Combined
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes (Combined)";
 
 	heavyArmor[] = {
@@ -190,6 +191,7 @@ class There_is_Only_War_Adeptus_Astartes_Combined
 
 class There_is_Only_War_Adeptus_Astartes_BT
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Black Templars";
 
 	heavyArmor[] = {
@@ -220,6 +222,7 @@ class There_is_Only_War_Adeptus_Astartes_BT
 
 class There_is_Only_War_Adeptus_Astartes_Combined_BA
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Blood Angels";
 
 	heavyArmor[] = {
@@ -249,6 +252,7 @@ class There_is_Only_War_Adeptus_Astartes_Combined_BA
 
 class There_is_Only_War_Adeptus_Astartes_BR
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Blood Ravens";
 
 	heavyArmor[] = {
@@ -278,6 +282,7 @@ class There_is_Only_War_Adeptus_Astartes_BR
 
 class There_is_Only_War_Adeptus_Astartes_DA
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Dark Angels";
 
 	heavyArmor[] = {
@@ -318,6 +323,7 @@ class There_is_Only_War_Adeptus_Astartes_DA
 
 class There_is_Only_War_Adeptus_Astartes_IF
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Imperial Fists";
 
 	heavyArmor[] = {
@@ -347,6 +353,7 @@ class There_is_Only_War_Adeptus_Astartes_IF
 
 class There_is_Only_War_Adeptus_Astartes_IH
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Iron Hands";
 
 	heavyArmor[] = {
@@ -376,6 +383,7 @@ class There_is_Only_War_Adeptus_Astartes_IH
 
 class There_is_Only_War_Adeptus_Astartes_RG
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Raven Guard";
 
 	heavyArmor[] = {
@@ -404,6 +412,7 @@ class There_is_Only_War_Adeptus_Astartes_RG
 
 class There_is_Only_War_Adeptus_Astartes_SL
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Salamanders";
 
 	heavyArmor[] = {
@@ -433,6 +442,7 @@ class There_is_Only_War_Adeptus_Astartes_SL
 
 class There_is_Only_War_Adeptus_Astartes_SW
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Space Wolves";
 
 	heavyArmor[] = {
@@ -462,6 +472,7 @@ class There_is_Only_War_Adeptus_Astartes_SW
 
 class There_is_Only_War_Adeptus_Astartes_UM
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: Ultramarines";
 
 	heavyArmor[] = {
@@ -491,6 +502,7 @@ class There_is_Only_War_Adeptus_Astartes_UM
 
 class There_is_Only_War_Adeptus_Astartes_WS
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Adeptus Astartes: White Scars";
 
 	heavyArmor[] = {

--- a/Headers/descriptionEXT/Faction Headers/There is Only War Xenos Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/There is Only War Xenos Unit Table.hpp
@@ -1,5 +1,6 @@
 class There_is_Only_War_Xenos_Necrons
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
 	displayName = "There is Only War - Necrons";
 
 	infantry[] = {
@@ -24,6 +25,7 @@ class There_is_Only_War_Xenos_Necrons
 
 class There_is_Only_War_Xenos_Orks
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
    displayName = "There is Only War - Orks";
 
    infantry[] = {
@@ -62,6 +64,7 @@ class There_is_Only_War_Xenos_Orks
 
 class There_is_Only_War_Xenos_Tau_DY
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
    displayName = "There is Only War - Tau: Dal'Yth Sept";
 
    infantry[] = {
@@ -98,6 +101,7 @@ class There_is_Only_War_Xenos_Tau_DY
 
 class There_is_Only_War_Xenos_Tau_FE
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
    displayName = "There is Only War - Tau: Farsight Enclave";
 
    infantry[] = {
@@ -134,6 +138,7 @@ class There_is_Only_War_Xenos_Tau_FE
 
 class There_is_Only_War_Xenos_Tau_SC
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
    displayName = "There is Only War - Tau: Sa'Cea Sept";
 
    infantry[] = {
@@ -170,6 +175,7 @@ class There_is_Only_War_Xenos_Tau_SC
 
 class There_is_Only_War_Xenos_Tau_VL
 {
+	dependencies[] = { "@There is Only War Mod - Release 5 BETA" };
    displayName = "There is Only War - Tau: Vior'La Sept";
 
    infantry[] = {

--- a/Headers/descriptionEXT/Faction Headers/Vanilla Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Vanilla Unit Table.hpp
@@ -1,5 +1,6 @@
 class AAF_faction
 {
+	dependencies[] = { "A3" };
 	displayName = "VANILLA - AAF";
 	lightCars[] = {
 		"B_T_LSV_01_armed_F"
@@ -62,6 +63,7 @@ class AAF_faction
 
 class CSAT_faction
 {
+	dependencies[] = { "A3" };
 	displayName = "VANILLA - CSAT";
 	lightCars[] = {
 		"O_LSV_02_armed_F"
@@ -134,6 +136,7 @@ class CSAT_faction
 
 class CSAT_urban_faction : CSAT_faction
 {
+	dependencies[] = { "A3" };
 	displayName = "VANILLA - CSAT URBAN";
 	attackHelicopters[] = {
 		"O_Heli_Attack_02_dynamicLoadout_black_F"
@@ -142,6 +145,7 @@ class CSAT_urban_faction : CSAT_faction
 
 class CSAT_pacific_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - CSAT PACIFIC";
 	lightCars[] = {
 		"O_T_LSV_02_armed_F"
@@ -217,6 +221,7 @@ class CSAT_pacific_faction
 
 class VIPER_faction : CSAT_pacific_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - VIPER";
 	infantry[] = {
 		"O_V_Soldier_Exp_hex_F",
@@ -231,6 +236,7 @@ class VIPER_faction : CSAT_pacific_faction
 
 class VIPER_pacific_faction : CSAT_pacific_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - VIPER PACIFIC";
 	infantry[] = {
 		"O_V_Soldier_Exp_ghex_F",
@@ -245,6 +251,7 @@ class VIPER_pacific_faction : CSAT_pacific_faction
 
 class NATO_faction
 {
+	dependencies[] = { "A3" };
 	displayName = "VANILLA - NATO";
 	lightCars[] = {
 		"B_LSV_01_armed_F"
@@ -331,6 +338,7 @@ class NATO_faction
 
 class NATO_pacific_faction : NATO_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - NATO PACIFIC";
 	lightCars[] = {
 		"B_T_LSV_01_armed_F"
@@ -392,6 +400,7 @@ class NATO_pacific_faction : NATO_faction
 
 class NATO_woodland_faction : NATO_pacific_faction
 {
+	dependencies[] = { "enoch" };
 	displayName = "CONTACT - NATO WOODLAND";
 	infantry[] = {
 		"B_W_Soldier_A_F",
@@ -429,6 +438,7 @@ class NATO_woodland_faction : NATO_pacific_faction
 
 class CTRG_pacific_faction : NATO_pacific_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - CTRG PACIFIC";
 	transportHelicopters[] = {
 		"B_CTRG_Heli_Transport_01_sand_F",
@@ -458,6 +468,7 @@ class CTRG_pacific_faction : NATO_pacific_faction
 
 class FIA_faction
 {
+	dependencies[] = { "A3" };
 	displayName = "VANILLA - FIA";
 	lightCars[] = {
 		"I_C_Offroad_02_LMG_F",
@@ -490,6 +501,7 @@ class FIA_faction
 
 class SYNDIKAT_faction : FIA_faction
 {
+	dependencies[] = { "expansion" };
 	displayName = "APEX - SYNDIKAT";
 	infantry[] = {
 		"I_C_Soldier_Bandit_3_F",
@@ -512,6 +524,7 @@ class SYNDIKAT_faction : FIA_faction
 
 class LDF_faction
 {
+	dependencies[] = { "enoch" };
 	displayName = "CONTACT - LDF";
 	lightCars[] = {
 		"I_C_Offroad_02_LMG_F",
@@ -568,6 +581,7 @@ class LDF_faction
 
 class SPETZNAS_CONTACT_faction : VIPER_pacific_faction
 {
+	dependencies[] = { "enoch" };
 	displayName = "CONTACT - Spetznas";
 	infantry[] = {
 		"O_R_Soldier_TL_F",

--- a/Headers/descriptionEXT/Faction Headers/Zombies And Demons Unit Table.hpp
+++ b/Headers/descriptionEXT/Faction Headers/Zombies And Demons Unit Table.hpp
@@ -1,5 +1,6 @@
 class ZND_BRTILLE_CRAWLERS_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Brittle Crawlers";
 
 	infantry[] = {
@@ -40,6 +41,7 @@ class ZND_BRTILLE_CRAWLERS_faction
 
 class ZND_DEMONS_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Demons";
 
 	infantry[] = {
@@ -80,6 +82,7 @@ class ZND_DEMONS_faction
 
 class ZND_FAST_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Fast Zombies";
 
 	infantry[] = {
@@ -131,6 +134,7 @@ class ZND_FAST_faction
 
 class ZND_MEDIUM_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Medium Zombies";
 
 	infantry[] = {
@@ -182,6 +186,7 @@ class ZND_MEDIUM_faction
 
 class ZND_SLOW_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Slow Zombies";
 
 	infantry[] = {
@@ -233,6 +238,7 @@ class ZND_SLOW_faction
 
 class ZND_SPIDERS_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Spider Zombies";
 
 	infantry[] = {
@@ -273,6 +279,7 @@ class ZND_SPIDERS_faction
 
 class ZND_WALKERS_faction
 {
+	dependencies[] = { "@Zombies and Demons" };
 	displayName = "Zombies & Demons - Walkers";
 
 	infantry[] = {


### PR DESCRIPTION
Since the faction list in the UI got extremely cluttered, it seemed useful to add a system which only shows the factions that are available with the currently loaded mods.

A few notes:
- The `dependencies` do not include the transitive dependencies, but this shouldn't be a very big issue.
- I don't own 'SOG Prairie Fire', I found online that the respective classname was `VN`, but I have no way of verifying if this is actually correct.
- I couldn't find the mod that corresponds to `JTFS Armory`. It seems to be some Halo inspired mod, but I couldn't find it. So the dependency is set to `???` for now.